### PR TITLE
feat: create Anthropic Claude API wrapper (closes #54)

### DIFF
--- a/lib/ai/claude.ts
+++ b/lib/ai/claude.ts
@@ -1,0 +1,130 @@
+import Anthropic from '@anthropic-ai/sdk'
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+})
+
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 4096
+const TIMEOUT_MS = 60000
+
+export interface ClaudeMessage {
+  role: 'user' | 'assistant'
+  content: string | ClaudeContentBlock[]
+}
+
+export interface ClaudeContentBlock {
+  type: 'text' | 'image'
+  text?: string
+  source?: {
+    type: 'base64'
+    media_type: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif'
+    data: string
+  }
+}
+
+export interface ClaudeResponse {
+  content: string
+  usage: {
+    inputTokens: number
+    outputTokens: number
+  }
+  model: string
+}
+
+/**
+ * Send a text-only message to Claude
+ */
+export async function analyzeText(
+  systemPrompt: string,
+  userPrompt: string
+): Promise<ClaudeResponse> {
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: MAX_TOKENS,
+    system: systemPrompt,
+    messages: [
+      { role: 'user', content: userPrompt }
+    ],
+  })
+
+  const textContent = response.content.find(block => block.type === 'text')
+
+  return {
+    content: textContent?.type === 'text' ? textContent.text : '',
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+    model: response.model,
+  }
+}
+
+/**
+ * Send a message with an image to Claude (vision)
+ */
+export async function analyzeWithVision(
+  systemPrompt: string,
+  userPrompt: string,
+  imageBase64: string,
+  mediaType: 'image/jpeg' | 'image/png' | 'image/webp' = 'image/jpeg'
+): Promise<ClaudeResponse> {
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: MAX_TOKENS,
+    system: systemPrompt,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: mediaType,
+              data: imageBase64,
+            },
+          },
+          {
+            type: 'text',
+            text: userPrompt,
+          },
+        ],
+      },
+    ],
+  })
+
+  const textContent = response.content.find(block => block.type === 'text')
+
+  return {
+    content: textContent?.type === 'text' ? textContent.text : '',
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+    model: response.model,
+  }
+}
+
+/**
+ * Fetch an image from URL and convert to base64
+ */
+export async function imageUrlToBase64(imageUrl: string): Promise<{
+  base64: string
+  mediaType: 'image/jpeg' | 'image/png' | 'image/webp'
+}> {
+  const response = await fetch(imageUrl)
+  const arrayBuffer = await response.arrayBuffer()
+  const base64 = Buffer.from(arrayBuffer).toString('base64')
+
+  const contentType = response.headers.get('content-type') || 'image/jpeg'
+  let mediaType: 'image/jpeg' | 'image/png' | 'image/webp' = 'image/jpeg'
+
+  if (contentType.includes('png')) {
+    mediaType = 'image/png'
+  } else if (contentType.includes('webp')) {
+    mediaType = 'image/webp'
+  }
+
+  return { base64, mediaType }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\""
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.2",
     "@hookform/resolvers": "^5.2.2",
     "@prisma/client": "^5.0.0",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.71.2
+        version: 0.71.2(zod@4.3.5)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.0(react@18.3.1))
@@ -126,6 +129,19 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.71.2':
+    resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -1720,6 +1736,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2361,6 +2381,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -2505,6 +2528,14 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.71.2(zod@4.3.5)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.5
+
+  '@babel/runtime@7.28.6': {}
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -4267,6 +4298,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -4893,6 +4929,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Issue: #54 

- Install @anthropic-ai/sdk package
- Create Claude API wrapper with text and vision analysis functions
- Add imageUrlToBase64 utility for fetching and converting images
- Support JPEG, PNG, and WebP image formats
- Configure Claude Sonnet 4 model with 4096 max tokens