### PR TITLE
feat: add voice dictation to diagnosis descriptions

### DIFF
--- a/app/(app)/diagnose/hybrid/page.tsx
+++ b/app/(app)/diagnose/hybrid/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ChevronRight, CheckCircle2, Circle } from "lucide-react";
+import { ChevronRight, CheckCircle2, Circle, Mic, MicOff } from "lucide-react";
 import { toast } from "sonner";
 import {
   hybridDiagnoseSchema,
@@ -13,6 +13,7 @@ import {
   GROWTH_STAGES,
 } from "@/lib/validations/diagnose";
 import { CROP_OPTIONS, LOCATIONS } from "@/lib/constants/profile";
+import { useSpeechRecognition } from "@/lib/hooks/use-speech-recognition";
 import { ImageUploadZone } from "@/components/diagnose/image-upload-zone";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -66,6 +67,27 @@ export default function HybridDiagnosePage() {
   });
 
   const description = form.watch("description");
+  const handleTranscript = useCallback(
+    (transcript: string) => {
+      const currentValue = form.getValues("description") || "";
+      const nextValue = currentValue
+        ? `${currentValue.trimEnd()} ${transcript}`.trim()
+        : transcript;
+      form.setValue("description", nextValue, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    },
+    [form]
+  );
+
+  const {
+    isSupported: isSpeechSupported,
+    isRecording,
+    error: speechError,
+    start: startDictation,
+    stop: stopDictation,
+  } = useSpeechRecognition({ onTranscript: handleTranscript });
 
   useEffect(() => {
     async function fetchProfile() {
@@ -280,7 +302,30 @@ export default function HybridDiagnosePage() {
                 name="description"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Description</FormLabel>
+                    <div className="flex items-center justify-between">
+                      <FormLabel>Description</FormLabel>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={isRecording ? stopDictation : startDictation}
+                        disabled={!isSpeechSupported}
+                        aria-pressed={isRecording}
+                        title={
+                          isSpeechSupported
+                            ? isRecording
+                              ? "Stop voice input"
+                              : "Start voice input"
+                            : "Voice input not supported in this browser"
+                        }
+                      >
+                        {isRecording ? (
+                          <MicOff className="h-4 w-4" />
+                        ) : (
+                          <Mic className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
                     <FormControl>
                       <Textarea
                         placeholder="Describe what you see: yellowing leaves, spots, wilting, etc."
@@ -289,7 +334,12 @@ export default function HybridDiagnosePage() {
                       />
                     </FormControl>
                     <FormDescription>
-                      {description?.length || 0}/1000 characters
+                      <span>{description?.length || 0}/1000 characters</span>
+                      {speechError && (
+                        <span className="block text-destructive">
+                          Voice input error: {speechError}
+                        </span>
+                      )}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/lib/hooks/use-speech-recognition.ts
+++ b/lib/hooks/use-speech-recognition.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative | null;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult | null;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognition;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+export interface UseSpeechRecognitionOptions {
+  onTranscript: (text: string) => void;
+  lang?: string;
+}
+
+export interface UseSpeechRecognitionResult {
+  isSupported: boolean;
+  isRecording: boolean;
+  error: string | null;
+  start: () => void;
+  stop: () => void;
+}
+
+function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+}
+
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions
+): UseSpeechRecognitionResult {
+  const { onTranscript, lang = "en-US" } = options;
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const [isSupported, setIsSupported] = useState<boolean>(false);
+  const [isRecording, setIsRecording] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect((): void => {
+    setIsSupported(getSpeechRecognitionConstructor() !== null);
+  }, []);
+
+  const stop = useCallback((): void => {
+    if (recognitionRef.current) {
+      recognitionRef.current.stop();
+    }
+    setIsRecording(false);
+  }, []);
+
+  const start = useCallback((): void => {
+    const SpeechRecognitionCtor = getSpeechRecognitionConstructor();
+    if (!SpeechRecognitionCtor) {
+      setError("Speech recognition is not supported in this browser.");
+      return;
+    }
+
+    const recognition = new SpeechRecognitionCtor();
+    recognitionRef.current = recognition;
+    recognition.lang = lang;
+    recognition.interimResults = false;
+    recognition.continuous = false;
+
+    recognition.onresult = (event: SpeechRecognitionEvent): void => {
+      let transcript = "";
+
+      for (let i = 0; i < event.results.length; i += 1) {
+        const result = event.results.item(i);
+        if (!result || !result.isFinal) {
+          continue;
+        }
+        const alternative = result.item(0);
+        if (alternative) {
+          transcript += `${alternative.transcript} `;
+        }
+      }
+
+      const trimmed = transcript.trim();
+      if (trimmed.length > 0) {
+        onTranscript(trimmed);
+      }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent): void => {
+      setError(event.error);
+      setIsRecording(false);
+    };
+
+    recognition.onend = (): void => {
+      setIsRecording(false);
+    };
+
+    setError(null);
+    setIsRecording(true);
+    recognition.start();
+  }, [lang, onTranscript]);
+
+  useEffect((): (() => void) => {
+    return (): void => {
+      if (recognitionRef.current) {
+        recognitionRef.current.stop();
+        recognitionRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    isSupported,
+    isRecording,
+    error,
+    start,
+    stop,
+  };
+}


### PR DESCRIPTION
### Motivation
- Add a lightweight browser-based voice dictation option for diagnosis description fields to improve input ergonomics.
- Keep this change isolated from the larger TypeScript refactor by creating a focused feature PR that targets `main`.
- Provide a small reusable hook with clear lifecycle, error handling, and a simple UI surface so the feature can be reused elsewhere.

### Description
- Add a new hook `lib/hooks/use-speech-recognition.ts` that wraps the Web Speech API with TypeScript typings, `start`/`stop` controls, recording state, and error reporting.
- Integrate mic controls and a transcript-appending flow into `app/(app)/diagnose/photo/page.tsx` so users can start/stop dictation and have transcripts appended to the `description` field.
- Add the same mic control, transcript handling, and error display to `app/(app)/diagnose/hybrid/page.tsx`, and include `Mic`/`MicOff` icons and a `handleTranscript` helper to merge new transcripts with existing text.

### Testing
- Ran `pnpm exec tsc --noEmit` and the TypeScript check completed without emit errors.
- Ran `pnpm run lint` and it completed with a known `@next/next/no-img-element` warning for the image preview.
- Started the dev server and ran a Playwright script that captured screenshots of `/diagnose/photo` and `/diagnose/hybrid`, though the dev server logs showed a missing Supabase environment variable in `middleware` which can impact full page rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969f91340f88330b91a22ed68cfd032)