### PR TITLE
Align initial migration with Prisma schema (add SourceType enum, update Input/Recommendation/Source, add indexes)

### DIFF
--- a/prisma/migrations/20260113014928_init/migration.sql
+++ b/prisma/migrations/20260113014928_init/migration.sql
@@ -1,6 +1,9 @@
 -- CreateExtension
 CREATE EXTENSION IF NOT EXISTS "vector";
 
+-- CreateEnum
+CREATE TYPE "SourceType" AS ENUM ('UNIVERSITY_EXTENSION', 'MANUFACTURER', 'RETAILER', 'RESEARCH_PAPER', 'GOVERNMENT');
+
 -- CreateTable
 CREATE TABLE "User" (
     "id" TEXT NOT NULL,
@@ -33,6 +36,9 @@ CREATE TABLE "Input" (
     "imageUrl" TEXT,
     "description" TEXT,
     "labData" JSONB,
+    "location" TEXT,
+    "crop" TEXT,
+    "season" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "Input_pkey" PRIMARY KEY ("id")
@@ -43,9 +49,10 @@ CREATE TABLE "Recommendation" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "inputId" TEXT NOT NULL,
-    "diagnosis" TEXT NOT NULL,
-    "actions" JSONB NOT NULL,
+    "diagnosis" JSONB NOT NULL,
     "confidence" DOUBLE PRECISION NOT NULL,
+    "modelUsed" TEXT NOT NULL,
+    "tokensUsed" INTEGER,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "Recommendation_pkey" PRIMARY KEY ("id")
@@ -70,7 +77,7 @@ CREATE TABLE "Source" (
     "id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "url" TEXT,
-    "sourceType" TEXT NOT NULL,
+    "sourceType" "SourceType" NOT NULL,
     "institution" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -146,6 +153,12 @@ CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "UserProfile_userId_key" ON "UserProfile"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Recommendation_inputId_key" ON "Recommendation"("inputId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Source_url_key" ON "Source"("url");
 
 -- AddForeignKey
 ALTER TABLE "UserProfile" ADD CONSTRAINT "UserProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
### Motivation
- Bring the initial SQL migration into alignment with the Prisma model so runtime DB schema matches application expectations.
- Ensure `Source.sourceType` uses a proper enum and `Input`/`Recommendation` columns reflect the types used by the app and generated client.
- Keep vector embedding column definitions consistent with the code that expects `vector(1536)` for text and `vector(512)` for images.

### Description
- Add a `SourceType` enum SQL type and change `Source.sourceType` to use `"SourceType"` instead of plain `TEXT`.
- Add `location`, `crop`, and `season` columns to the `Input` table to match the Prisma model.
- Change `Recommendation.diagnosis` to `JSONB` and add `modelUsed` (`TEXT`) and `tokensUsed` (`INTEGER`) columns to the `Recommendation` table.
- Add unique indexes for `Recommendation.inputId` and `Source.url` so database constraints match Prisma uniqueness.

### Testing
- Ran `pnpm lint`, which completed successfully and reported a Next.js `<img>` accessibility/optimization warning but no lint failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696f2f0afb3c8330a5b86f10c53c6cab)