### PR TITLE
Replace SageMaker with in-house model automation

### DIFF
--- a/.github/workflows/ops-daily-digest.yml
+++ b/.github/workflows/ops-daily-digest.yml
@@ -1,0 +1,64 @@
+name: Ops Daily Digest
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "35 14 * * *"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  digest:
+    name: Run Daily Ops Audits
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: production
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_AUDIT_REGIONS: ${{ vars.AWS_AUDIT_REGIONS || 'us-west-2,us-west-1,ca-west-1' }}
+      AWS_ROLE_TO_ASSUME: ${{ vars.AWS_AUDIT_ROLE_ARN }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      AUDIT_ENV: prod
+      ALLOW_LEGACY_ENV_FALLBACK: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run AWS ops audit
+        run: node tools/aws/ops-audit.mjs
+
+      - name: Run release readiness audit
+        run: |
+          mkdir -p reports
+          TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+          pnpm --filter @crop-copilot/api audit:release > "reports/release-readiness-${TIMESTAMP}.json"
+
+      - name: Generate digest markdown
+        run: node tools/ops/generate-daily-digest.mjs
+
+      - name: Upload ops artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ops-daily-digest
+          path: |
+            reports/aws-ops-audit-*.json
+            reports/release-readiness-*.json
+            reports/ops-daily-digest-*.md

--- a/.github/workflows/prod-db-ops.yml
+++ b/.github/workflows/prod-db-ops.yml
@@ -86,6 +86,12 @@ jobs:
             --query "StackResourceSummaries[?LogicalResourceId=='$DB_RESOURCE_LOGICAL_ID'].PhysicalResourceId | [0]" \
             --output text)
           if [ -z "$DB_INSTANCE_ID" ] || [ "$DB_INSTANCE_ID" = "None" ]; then
+            DB_INSTANCE_ID=$(aws cloudformation list-stack-resources \
+              --stack-name "$DB_STACK_NAME" \
+              --query "StackResourceSummaries[?ResourceType=='AWS::RDS::DBInstance'].PhysicalResourceId | [0]" \
+              --output text)
+          fi
+          if [ -z "$DB_INSTANCE_ID" ] || [ "$DB_INSTANCE_ID" = "None" ]; then
             echo "Failed to resolve DB instance from stack $DB_STACK_NAME logical id $DB_RESOURCE_LOGICAL_ID"
             exit 1
           fi

--- a/apps/api/sql/014_in_house_ml_artifacts.sql
+++ b/apps/api/sql/014_in_house_ml_artifacts.sql
@@ -1,0 +1,16 @@
+-- Migration 014: in-house ML artifact registry
+
+ALTER TABLE "MLModelVersion"
+  ADD COLUMN IF NOT EXISTS backend TEXT NOT NULL DEFAULT 'legacy',
+  ADD COLUMN IF NOT EXISTS artifact JSONB,
+  ADD COLUMN IF NOT EXISTS metrics JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+UPDATE "MLModelVersion"
+SET backend = CASE
+  WHEN backend = 'legacy' AND "s3Uri" IS NOT NULL THEN 'sagemaker_legacy'
+  ELSE backend
+END
+WHERE backend = 'legacy';
+
+CREATE INDEX IF NOT EXISTS idx_ml_model_version_type_status
+  ON "MLModelVersion" ("modelType", status, "trainedAt" DESC);

--- a/apps/api/src/auth/identity-store.ts
+++ b/apps/api/src/auth/identity-store.ts
@@ -4,7 +4,7 @@ import { resolvePoolSslConfig, sanitizeDatabaseUrlForPool } from '../lib/store';
 import { AuthError } from './errors';
 import type { AuthContext } from './types';
 
-export type AuthProvider = 'supabase' | 'cognito';
+export type AuthProvider = 'supabase' | 'cognito' | 'local';
 
 export interface VerifiedIdentity {
   provider: AuthProvider;

--- a/apps/api/src/auth/local-auth.test.ts
+++ b/apps/api/src/auth/local-auth.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import {
+  getLocalAuthContext,
+  isLocalAuthEnabled,
+  isLocalRequestEvent,
+  verifyLocalAccessTokenFromEvent,
+} from './local-auth';
+
+function buildEvent(
+  headers: Record<string, string> = {},
+  sourceIp = '127.0.0.1'
+): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'GET /api/v1/test',
+    rawPath: '/api/v1/test',
+    rawQueryString: '',
+    headers,
+    requestContext: {
+      accountId: 'local',
+      apiId: 'local',
+      domainName: 'localhost',
+      domainPrefix: 'localhost',
+      http: {
+        method: 'GET',
+        path: '/api/v1/test',
+        protocol: 'HTTP/1.1',
+        sourceIp,
+        userAgent: 'test',
+      },
+      requestId: 'req',
+      routeKey: 'GET /api/v1/test',
+      stage: '$default',
+      time: '',
+      timeEpoch: 0,
+    },
+    isBase64Encoded: false,
+  };
+}
+
+test('local auth is disabled by default', () => {
+  const previous = process.env.AUTH_PROVIDER;
+  delete process.env.AUTH_PROVIDER;
+  try {
+    assert.equal(isLocalAuthEnabled(), false);
+  } finally {
+    process.env.AUTH_PROVIDER = previous;
+  }
+});
+
+test('local request detection only allows localhost-like hosts', () => {
+  assert.equal(isLocalRequestEvent(buildEvent({ host: 'localhost:3000' })), true);
+  assert.equal(isLocalRequestEvent(buildEvent({ host: 'cropcopilot.app' }, '203.0.113.9')), false);
+});
+
+test('verifyLocalAccessTokenFromEvent returns the configured local auth context', () => {
+  const previousProvider = process.env.AUTH_PROVIDER;
+  const previousToken = process.env.LOCAL_AUTH_BEARER_TOKEN;
+
+  process.env.AUTH_PROVIDER = 'local';
+  process.env.LOCAL_AUTH_BEARER_TOKEN = 'test-local-token';
+
+  try {
+    const auth = verifyLocalAccessTokenFromEvent(
+      buildEvent({
+        host: 'localhost:3000',
+        authorization: 'Bearer test-local-token',
+      })
+    );
+
+    assert.equal(auth.authProvider, 'local');
+    assert.equal(auth.userId, getLocalAuthContext().userId);
+    assert.equal(auth.email, getLocalAuthContext().email);
+  } finally {
+    process.env.AUTH_PROVIDER = previousProvider;
+    process.env.LOCAL_AUTH_BEARER_TOKEN = previousToken;
+  }
+});

--- a/apps/api/src/auth/local-auth.ts
+++ b/apps/api/src/auth/local-auth.ts
@@ -1,0 +1,109 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { AuthError } from './errors';
+import { getBearerToken } from './supabase-auth';
+import type { AuthContext } from './types';
+
+const DEFAULT_LOCAL_USER_ID = '80d8a54f-5c9b-4094-905a-862baadfdb3c';
+const DEFAULT_LOCAL_EMAIL = 'avirajdhooria2001@gmail.com';
+const DEFAULT_LOCAL_TOKEN = 'crop-copilot-local-dev-token';
+
+function isTruthy(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase());
+}
+
+export function isLocalAuthEnabled(): boolean {
+  const explicit = (
+    process.env.AUTH_PROVIDER ??
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER ??
+    ''
+  )
+    .trim()
+    .toLowerCase();
+
+  if (explicit === 'local') {
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  return isTruthy(process.env.LOCAL_AUTH_ENABLED) && process.env.NODE_ENV !== 'production';
+}
+
+export function getLocalAuthToken(): string {
+  return process.env.LOCAL_AUTH_BEARER_TOKEN?.trim() || DEFAULT_LOCAL_TOKEN;
+}
+
+export function getLocalAuthContext(): AuthContext {
+  const userId = process.env.LOCAL_AUTH_USER_ID?.trim() || DEFAULT_LOCAL_USER_ID;
+  const email = process.env.LOCAL_AUTH_EMAIL?.trim() || DEFAULT_LOCAL_EMAIL;
+
+  return {
+    userId,
+    email,
+    scopes: ['admin', 'local'],
+    tokenUse: 'local',
+    authProvider: 'local',
+    authSubject: userId,
+  };
+}
+
+function getRequestHost(event: APIGatewayProxyEventV2): string {
+  const host =
+    event.headers?.host ??
+    event.headers?.Host ??
+    event.headers?.['x-forwarded-host'] ??
+    event.headers?.['X-Forwarded-Host'] ??
+    '';
+
+  return host.split(',')[0]?.trim().toLowerCase() ?? '';
+}
+
+function stripPort(host: string): string {
+  if (host.startsWith('[')) {
+    const index = host.indexOf(']');
+    return index >= 0 ? host.slice(1, index) : host;
+  }
+
+  return host.split(':')[0] ?? host;
+}
+
+export function isLocalRequestEvent(event: APIGatewayProxyEventV2): boolean {
+  const host = stripPort(getRequestHost(event));
+  if (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '0.0.0.0' ||
+    host === '::1' ||
+    host.endsWith('.localhost')
+  ) {
+    return true;
+  }
+
+  const sourceIp = event.requestContext?.http?.sourceIp?.trim().toLowerCase() ?? '';
+  return sourceIp === '127.0.0.1' || sourceIp === '::1' || sourceIp === '';
+}
+
+export function verifyLocalAccessTokenFromEvent(event: APIGatewayProxyEventV2): AuthContext {
+  if (!isLocalAuthEnabled()) {
+    throw new AuthError('Local auth is not enabled.', 500, 'AUTH_CONFIG_ERROR');
+  }
+
+  if (!isLocalRequestEvent(event)) {
+    throw new AuthError(
+      'Local auth is restricted to localhost development requests.',
+      403,
+      'LOCAL_AUTH_FORBIDDEN'
+    );
+  }
+
+  let token: string;
+  try {
+    token = getBearerToken(event.headers ?? {});
+  } catch {
+    throw new AuthError('Missing local auth bearer token.', 401, 'UNAUTHORIZED');
+  }
+
+  if (token !== getLocalAuthToken()) {
+    throw new AuthError('Invalid local auth bearer token.', 401, 'INVALID_TOKEN');
+  }
+
+  return getLocalAuthContext();
+}

--- a/apps/api/src/auth/types.ts
+++ b/apps/api/src/auth/types.ts
@@ -5,7 +5,7 @@ export interface AuthContext {
   email?: string;
   scopes: string[];
   tokenUse?: string;
-  authProvider?: 'supabase' | 'cognito';
+  authProvider?: 'supabase' | 'cognito' | 'local';
   authSubject?: string;
 }
 

--- a/apps/api/src/auth/verify-access-token.ts
+++ b/apps/api/src/auth/verify-access-token.ts
@@ -3,6 +3,7 @@ import type { APIGatewayProxyEventV2 } from 'aws-lambda';
 import { AuthError } from './errors';
 import { verifyCognitoToken } from './cognito-auth';
 import { resolveAuthenticatedUser } from './identity-store';
+import { isLocalAuthEnabled, verifyLocalAccessTokenFromEvent } from './local-auth';
 import {
   verifyAccessTokenFromEvent as verifySupabaseAccessTokenFromEvent,
   verifySupabaseIdentityFromEvent,
@@ -99,6 +100,10 @@ function detectProviderFromToken(token: string): 'cognito' | 'supabase' {
 export async function verifyAccessTokenFromEvent(
   event: APIGatewayProxyEventV2
 ): Promise<AuthContext> {
+  if (isLocalAuthEnabled()) {
+    return verifyLocalAccessTokenFromEvent(event);
+  }
+
   const cognitoCookieToken =
     readCookieValue(event, COGNITO_ID_TOKEN_COOKIE) ?? readCookieValue(event, COGNITO_ACCESS_TOKEN_COOKIE);
   if (cognitoCookieToken) {

--- a/apps/api/src/handlers/get-discovery-status.ts
+++ b/apps/api/src/handlers/get-discovery-status.ts
@@ -48,6 +48,8 @@ interface MLModelRow {
   feedbackCount: number;
   ndcgScore: number | null;
   s3Uri: string | null;
+  backend: string | null;
+  metrics: unknown;
   status: string;
   createdAt: string;
 }
@@ -994,7 +996,7 @@ export function buildGetDiscoveryStatusHandler(verifier?: AuthVerifier): APIGate
 
       // ── Phase 3: ML model stats ─────────────────────────────────────────────
       const mlResult = await db.query<MLModelRow>(`
-        SELECT id, "modelType", "trainedAt", "feedbackCount", "ndcgScore", "s3Uri", status, "createdAt"
+        SELECT id, "modelType", "trainedAt", "feedbackCount", "ndcgScore", "s3Uri", backend, metrics, status, "createdAt"
         FROM "MLModelVersion"
         WHERE "modelType" = 'lambdarank'
         ORDER BY "trainedAt" DESC
@@ -1003,7 +1005,7 @@ export function buildGetDiscoveryStatusHandler(verifier?: AuthVerifier): APIGate
       const latestModel = mlResult.rows[0] ?? null;
 
       const premiumModelResult = await db.query<MLModelRow>(`
-        SELECT id, "modelType", "trainedAt", "feedbackCount", "ndcgScore", "s3Uri", status, "createdAt"
+        SELECT id, "modelType", "trainedAt", "feedbackCount", "ndcgScore", "s3Uri", backend, metrics, status, "createdAt"
         FROM "MLModelVersion"
         WHERE "modelType" = 'premium_quality'
         ORDER BY "trainedAt" DESC
@@ -1084,6 +1086,8 @@ export function buildGetDiscoveryStatusHandler(verifier?: AuthVerifier): APIGate
                 feedbackCount: Number(latestModel.feedbackCount),
                 ndcgScore: latestModel.ndcgScore != null ? Number(latestModel.ndcgScore) : null,
                 s3Uri: latestModel.s3Uri ?? null,
+                backend: latestModel.backend ?? null,
+                metrics: latestModel.metrics ?? null,
               }
             : null,
           latestPremiumModel: latestPremiumModel
@@ -1098,6 +1102,8 @@ export function buildGetDiscoveryStatusHandler(verifier?: AuthVerifier): APIGate
                     ? Number(latestPremiumModel.ndcgScore)
                     : null,
                 s3Uri: latestPremiumModel.s3Uri ?? null,
+                backend: latestPremiumModel.backend ?? null,
+                metrics: latestPremiumModel.metrics ?? null,
               }
             : null,
           // App analytics

--- a/apps/api/src/ml/in-house-models.test.ts
+++ b/apps/api/src/ml/in-house-models.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getDefaultModelArtifact,
+  normalizeModelScore,
+  scoreFeatureVector,
+  trainLinearRankingModel,
+  type RankingExample,
+} from './in-house-models';
+import { RETRIEVAL_FEATURE_NAMES } from './reranker';
+import { PREMIUM_FEATURE_NAMES, buildPremiumQualityCheck } from './premium-quality';
+
+test('trainLinearRankingModel learns to rank stronger examples above weaker ones', () => {
+  const examples: RankingExample[] = [
+    {
+      qid: 'q1',
+      label: 2,
+      features: [0.95, 0.82, 1, 0.18, 1, 0.9, 0.1],
+    },
+    {
+      qid: 'q1',
+      label: 0,
+      features: [0.25, 0.3, 0.4, 0, 0, 0.1, 0.9],
+    },
+    {
+      qid: 'q2',
+      label: 2,
+      features: [0.88, 0.77, 0.9, 0.12, 1, 0.8, 0.2],
+    },
+    {
+      qid: 'q2',
+      label: 0,
+      features: [0.2, 0.22, 0.5, -0.02, 0, 0.05, 1],
+    },
+  ];
+
+  const model = trainLinearRankingModel({
+    modelType: 'lambdarank',
+    featureNames: [...RETRIEVAL_FEATURE_NAMES],
+    examples,
+    defaultWeights: getDefaultModelArtifact('lambdarank', [...RETRIEVAL_FEATURE_NAMES]).featureWeights,
+  });
+
+  const highScore = scoreFeatureVector(examples[0]!.features, model);
+  const lowScore = scoreFeatureVector(examples[1]!.features, model);
+
+  assert.ok(highScore > lowScore);
+  assert.ok((model.metrics.pairwiseAccuracy ?? 0) >= 1);
+  assert.ok((model.metrics.ndcgAt3 ?? 0) >= 1);
+});
+
+test('premium quality check surfaces weak support coverage as a conflict signal', () => {
+  const model = getDefaultModelArtifact('premium_quality', [...PREMIUM_FEATURE_NAMES]);
+  const weakCheck = buildPremiumQualityCheck({
+    artifact: model,
+    payload: {
+      riskReview: 'needs_manual_verification',
+      checks: [],
+      costAnalysis: null,
+      sprayWindows: [{ startsAt: '', endsAt: '', score: 50, summary: '', source: 'fallback' }],
+      report: null,
+    },
+  });
+
+  assert.equal(weakCheck.id, 'premium_quality_confidence');
+  assert.equal(typeof weakCheck.evidence?.qualityScore, 'number');
+  assert.ok(normalizeModelScore(scoreFeatureVector([0.4, 0, 0, 0, 0, 0, 0], model), model) >= 0);
+});

--- a/apps/api/src/ml/in-house-models.ts
+++ b/apps/api/src/ml/in-house-models.ts
@@ -1,0 +1,391 @@
+export type SupportedModelType = 'lambdarank' | 'premium_quality';
+
+export interface RankingExample {
+  qid: string;
+  label: number;
+  features: number[];
+}
+
+export interface InHouseModelMetrics {
+  ndcgAt3: number | null;
+  ndcgAt5: number | null;
+  baselineNdcgAt3: number | null;
+  baselineNdcgAt5: number | null;
+  pairwiseAccuracy: number | null;
+  baselinePairwiseAccuracy: number | null;
+}
+
+export interface InHouseLinearModelArtifact {
+  backend: 'in_house_linear_v1';
+  modelType: SupportedModelType;
+  trainedAt: string;
+  featureNames: string[];
+  featureWeights: number[];
+  bias: number;
+  scoreRange: {
+    min: number;
+    max: number;
+  };
+  sampleCount: number;
+  queryCount: number;
+  pairCount: number;
+  metrics: InHouseModelMetrics;
+}
+
+export interface TrainLinearRankingModelParams {
+  modelType: SupportedModelType;
+  featureNames: string[];
+  examples: RankingExample[];
+  defaultWeights: number[];
+  trainedAt?: string;
+}
+
+const LABEL_GAIN = [0, 1, 3];
+
+const DEFAULT_RETRIEVAL_WEIGHTS = normalizeWeights([
+  0.3, 0.24, 0.12, 0.11, 0.16, 0.1, -0.08,
+]);
+
+const DEFAULT_PREMIUM_WEIGHTS = normalizeWeights([
+  0.15, 0.14, 0.2, -0.2, 0.1, 0.12, 0.09,
+]);
+
+export function getDefaultModelArtifact(
+  modelType: SupportedModelType,
+  featureNames: string[],
+): InHouseLinearModelArtifact {
+  const defaultWeights =
+    modelType === 'premium_quality' ? DEFAULT_PREMIUM_WEIGHTS : DEFAULT_RETRIEVAL_WEIGHTS;
+
+  return {
+    backend: 'in_house_linear_v1',
+    modelType,
+    trainedAt: new Date(0).toISOString(),
+    featureNames,
+    featureWeights: defaultWeights.slice(0, featureNames.length),
+    bias: 0,
+    scoreRange: {
+      min: -1,
+      max: 1,
+    },
+    sampleCount: 0,
+    queryCount: 0,
+    pairCount: 0,
+    metrics: {
+      ndcgAt3: null,
+      ndcgAt5: null,
+      baselineNdcgAt3: null,
+      baselineNdcgAt5: null,
+      pairwiseAccuracy: null,
+      baselinePairwiseAccuracy: null,
+    },
+  };
+}
+
+export function trainLinearRankingModel(
+  params: TrainLinearRankingModelParams
+): InHouseLinearModelArtifact {
+  const { modelType, featureNames, examples, defaultWeights } = params;
+  const usableGroups = toUsableGroups(examples);
+  const fallbackArtifact = getDefaultModelArtifact(modelType, featureNames);
+
+  if (usableGroups.length === 0) {
+    return {
+      ...fallbackArtifact,
+      trainedAt: params.trainedAt ?? new Date().toISOString(),
+      sampleCount: examples.length,
+    };
+  }
+
+  const learned = computePairwiseWeights(usableGroups, featureNames.length);
+  const pairCount = learned.pairCount;
+  const blend = clamp(usableGroups.length / 60, 0.35, 0.85);
+  const normalizedLearned = normalizeWeights(learned.weights);
+  const normalizedDefault = normalizeWeights(defaultWeights);
+  const featureWeights = normalizeWeights(
+    normalizedLearned.map((value, index) => {
+      const base = normalizedDefault[index] ?? 0;
+      return value * blend + base * (1 - blend);
+    })
+  );
+
+  const provisionalArtifact: InHouseLinearModelArtifact = {
+    backend: 'in_house_linear_v1',
+    modelType,
+    trainedAt: params.trainedAt ?? new Date().toISOString(),
+    featureNames,
+    featureWeights,
+    bias: 0,
+    scoreRange: {
+      min: 0,
+      max: 1,
+    },
+    sampleCount: examples.length,
+    queryCount: usableGroups.length,
+    pairCount,
+    metrics: {
+      ndcgAt3: null,
+      ndcgAt5: null,
+      baselineNdcgAt3: null,
+      baselineNdcgAt5: null,
+      pairwiseAccuracy: null,
+      baselinePairwiseAccuracy: null,
+    },
+  };
+
+  const scoreRange = computeScoreRange(examples, provisionalArtifact);
+  const artifact = {
+    ...provisionalArtifact,
+    scoreRange,
+  };
+
+  const defaultArtifact = {
+    ...fallbackArtifact,
+    featureNames,
+    featureWeights: normalizedDefault.slice(0, featureNames.length),
+  };
+
+  return {
+    ...artifact,
+    metrics: evaluateRankingModel(examples, artifact, defaultArtifact),
+  };
+}
+
+export function scoreFeatureVector(
+  features: number[],
+  artifact: InHouseLinearModelArtifact
+): number {
+  const weights = artifact.featureWeights ?? [];
+  let score = artifact.bias ?? 0;
+  for (let index = 0; index < Math.min(features.length, weights.length); index += 1) {
+    const feature = Number(features[index] ?? 0);
+    const weight = Number(weights[index] ?? 0);
+    if (!Number.isFinite(feature) || !Number.isFinite(weight)) {
+      continue;
+    }
+    score += feature * weight;
+  }
+  return score;
+}
+
+export function normalizeModelScore(
+  score: number,
+  artifact: InHouseLinearModelArtifact
+): number {
+  const min = Number(artifact.scoreRange?.min ?? 0);
+  const max = Number(artifact.scoreRange?.max ?? 1);
+  if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) {
+    return clamp(sigmoid(score), 0, 1);
+  }
+  return clamp((score - min) / (max - min), 0, 1);
+}
+
+export function isInHouseModelArtifact(value: unknown): value is InHouseLinearModelArtifact {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.backend === 'in_house_linear_v1' &&
+    (candidate.modelType === 'lambdarank' || candidate.modelType === 'premium_quality') &&
+    Array.isArray(candidate.featureNames) &&
+    Array.isArray(candidate.featureWeights)
+  );
+}
+
+function toUsableGroups(examples: RankingExample[]): RankingExample[][] {
+  const grouped = new Map<string, RankingExample[]>();
+
+  for (const example of examples) {
+    if (!grouped.has(example.qid)) {
+      grouped.set(example.qid, []);
+    }
+    grouped.get(example.qid)!.push(example);
+  }
+
+  return [...grouped.values()].filter((group) => {
+    const labels = new Set(group.map((entry) => entry.label));
+    return group.length > 1 && labels.size > 1;
+  });
+}
+
+function computePairwiseWeights(
+  groups: RankingExample[][],
+  featureCount: number
+): { weights: number[]; pairCount: number } {
+  const weights = new Array<number>(featureCount).fill(0);
+  let pairCount = 0;
+
+  for (const group of groups) {
+    for (let left = 0; left < group.length; left += 1) {
+      for (let right = left + 1; right < group.length; right += 1) {
+        const a = group[left]!;
+        const b = group[right]!;
+        if (a.label === b.label) {
+          continue;
+        }
+
+        const high = a.label > b.label ? a : b;
+        const low = a.label > b.label ? b : a;
+        const gap = Math.abs(high.label - low.label);
+        pairCount += gap;
+
+        for (let featureIndex = 0; featureIndex < featureCount; featureIndex += 1) {
+          const highValue = Number(high.features[featureIndex] ?? 0);
+          const lowValue = Number(low.features[featureIndex] ?? 0);
+          weights[featureIndex] += (highValue - lowValue) * gap;
+        }
+      }
+    }
+  }
+
+  if (pairCount === 0) {
+    return {
+      weights,
+      pairCount,
+    };
+  }
+
+  return {
+    weights: weights.map((value) => value / pairCount),
+    pairCount,
+  };
+}
+
+function evaluateRankingModel(
+  examples: RankingExample[],
+  artifact: InHouseLinearModelArtifact,
+  baseline: InHouseLinearModelArtifact
+): InHouseModelMetrics {
+  const groups = toUsableGroups(examples);
+  if (groups.length === 0) {
+    return {
+      ndcgAt3: null,
+      ndcgAt5: null,
+      baselineNdcgAt3: null,
+      baselineNdcgAt5: null,
+      pairwiseAccuracy: null,
+      baselinePairwiseAccuracy: null,
+    };
+  }
+
+  const ndcgAt3 = average(groups.map((group) => ndcgForGroup(group, artifact, 3)));
+  const ndcgAt5 = average(groups.map((group) => ndcgForGroup(group, artifact, 5)));
+  const baselineNdcgAt3 = average(groups.map((group) => ndcgForGroup(group, baseline, 3)));
+  const baselineNdcgAt5 = average(groups.map((group) => ndcgForGroup(group, baseline, 5)));
+
+  return {
+    ndcgAt3,
+    ndcgAt5,
+    baselineNdcgAt3,
+    baselineNdcgAt5,
+    pairwiseAccuracy: pairwiseAccuracy(groups, artifact),
+    baselinePairwiseAccuracy: pairwiseAccuracy(groups, baseline),
+  };
+}
+
+function pairwiseAccuracy(
+  groups: RankingExample[][],
+  artifact: InHouseLinearModelArtifact
+): number | null {
+  let correct = 0;
+  let total = 0;
+
+  for (const group of groups) {
+    for (let left = 0; left < group.length; left += 1) {
+      for (let right = left + 1; right < group.length; right += 1) {
+        const a = group[left]!;
+        const b = group[right]!;
+        if (a.label === b.label) {
+          continue;
+        }
+        total += 1;
+        const aScore = scoreFeatureVector(a.features, artifact);
+        const bScore = scoreFeatureVector(b.features, artifact);
+        if ((a.label > b.label && aScore >= bScore) || (b.label > a.label && bScore >= aScore)) {
+          correct += 1;
+        }
+      }
+    }
+  }
+
+  return total > 0 ? correct / total : null;
+}
+
+function ndcgForGroup(
+  group: RankingExample[],
+  artifact: InHouseLinearModelArtifact,
+  k: number
+): number {
+  const ranked = [...group].sort(
+    (left, right) => scoreFeatureVector(right.features, artifact) - scoreFeatureVector(left.features, artifact)
+  );
+  const ideal = [...group].sort((left, right) => right.label - left.label);
+  const actualDcg = dcg(ranked.slice(0, k).map((entry) => entry.label));
+  const idealDcg = dcg(ideal.slice(0, k).map((entry) => entry.label));
+  if (idealDcg <= 0) {
+    return 0;
+  }
+  return actualDcg / idealDcg;
+}
+
+function dcg(labels: number[]): number {
+  return labels.reduce((sum, label, index) => {
+    const gain = LABEL_GAIN[label] ?? 0;
+    return sum + gain / Math.log2(index + 2);
+  }, 0);
+}
+
+function computeScoreRange(
+  examples: RankingExample[],
+  artifact: InHouseLinearModelArtifact
+): { min: number; max: number } {
+  if (examples.length === 0) {
+    return { min: -1, max: 1 };
+  }
+
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+
+  for (const example of examples) {
+    const score = scoreFeatureVector(example.features, artifact);
+    if (score < min) {
+      min = score;
+    }
+    if (score > max) {
+      max = score;
+    }
+  }
+
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min === max) {
+    return { min: min - 1 || -1, max: max + 1 || 1 };
+  }
+
+  return { min, max };
+}
+
+function normalizeWeights(weights: number[]): number[] {
+  const magnitude = weights.reduce((sum, value) => sum + Math.abs(value), 0);
+  if (!Number.isFinite(magnitude) || magnitude <= 0) {
+    return weights.map(() => 0);
+  }
+  return weights.map((value) => Number((value / magnitude).toFixed(6)));
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sigmoid(value: number): number {
+  return 1 / (1 + Math.exp(-value));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, value));
+}

--- a/apps/api/src/ml/model-registry.ts
+++ b/apps/api/src/ml/model-registry.ts
@@ -1,0 +1,230 @@
+import type { Pool } from 'pg';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+  getDefaultModelArtifact,
+  isInHouseModelArtifact,
+  type InHouseLinearModelArtifact,
+  type InHouseModelMetrics,
+  type SupportedModelType,
+} from './in-house-models';
+
+interface ModelVersionRow {
+  id: string;
+  backend: string | null;
+  artifact: unknown;
+  trained_at: Date;
+  feedback_count: number;
+  ndcg_score: number | null;
+  metrics: unknown;
+}
+
+interface CacheEntry {
+  artifact: InHouseLinearModelArtifact;
+  expiresAt: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const cache = new Map<string, CacheEntry>();
+
+export async function getLatestDeployedModelArtifact(
+  db: Pool,
+  params: {
+    modelType: SupportedModelType;
+    featureNames: string[];
+    cacheTtlMs?: number;
+  }
+): Promise<InHouseLinearModelArtifact> {
+  const cacheKey = `${params.modelType}:${params.featureNames.join(',')}`;
+  const now = Date.now();
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.artifact;
+  }
+
+  const result = await db.query<ModelVersionRow>(
+    `
+      SELECT
+        id,
+        backend,
+        artifact,
+        "trainedAt" AS trained_at,
+        "feedbackCount" AS feedback_count,
+        "ndcgScore" AS ndcg_score,
+        metrics
+      FROM "MLModelVersion"
+      WHERE "modelType" = $1
+        AND status = 'deployed'
+      ORDER BY "trainedAt" DESC
+      LIMIT 1
+    `,
+    [params.modelType]
+  );
+
+  const row = result.rows[0];
+  const artifact =
+    row && isInHouseModelArtifact(row.artifact)
+      ? {
+          ...row.artifact,
+          trainedAt: row.trained_at.toISOString(),
+          sampleCount: Number(row.feedback_count ?? row.artifact.sampleCount ?? 0),
+          metrics: normalizeMetrics(row.artifact.metrics ?? row.metrics),
+        }
+      : getDefaultModelArtifact(params.modelType, params.featureNames);
+
+  cache.set(cacheKey, {
+    artifact,
+    expiresAt: now + (params.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS),
+  });
+
+  return artifact;
+}
+
+export async function deployInHouseModelArtifact(
+  db: Pool,
+  params: {
+    modelVersionId: string;
+    artifact: InHouseLinearModelArtifact;
+    bucket?: string | null;
+    region?: string | null;
+  }
+): Promise<{ s3Uri: string | null }> {
+  const s3Uri = await uploadArtifactToS3(params.artifact, params.modelVersionId, {
+    bucket: params.bucket ?? null,
+    region: params.region ?? null,
+  });
+
+  await db.query('BEGIN');
+  try {
+    await db.query(
+      `
+        UPDATE "MLModelVersion"
+        SET status = 'retired', "updatedAt" = NOW()
+        WHERE "modelType" = $1
+          AND status = 'deployed'
+          AND id <> $2
+      `,
+      [params.artifact.modelType, params.modelVersionId]
+    );
+
+    await db.query(
+      `
+        UPDATE "MLModelVersion"
+        SET
+          status = 'deployed',
+          backend = $2,
+          artifact = $3::jsonb,
+          metrics = $4::jsonb,
+          "ndcgScore" = $5,
+          "s3Uri" = $6,
+          "trainedAt" = NOW(),
+          "updatedAt" = NOW()
+        WHERE id = $1
+      `,
+      [
+        params.modelVersionId,
+        params.artifact.backend,
+        JSON.stringify(params.artifact),
+        JSON.stringify(params.artifact.metrics ?? {}),
+        averageNdcg(params.artifact),
+        s3Uri,
+      ]
+    );
+
+    await db.query('COMMIT');
+  } catch (error) {
+    await db.query('ROLLBACK');
+    throw error;
+  }
+
+  invalidateCache(params.artifact.modelType);
+  return { s3Uri };
+}
+
+export async function retireModelVersion(
+  db: Pool,
+  modelVersionId: string
+): Promise<void> {
+  await db.query(
+    `
+      UPDATE "MLModelVersion"
+      SET status = 'retired', "updatedAt" = NOW()
+      WHERE id = $1
+    `,
+    [modelVersionId]
+  );
+  cache.clear();
+}
+
+function invalidateCache(modelType: SupportedModelType): void {
+  for (const key of cache.keys()) {
+    if (key.startsWith(`${modelType}:`)) {
+      cache.delete(key);
+    }
+  }
+}
+
+async function uploadArtifactToS3(
+  artifact: InHouseLinearModelArtifact,
+  modelVersionId: string,
+  options: {
+    bucket: string | null;
+    region: string | null;
+  }
+): Promise<string | null> {
+  if (!options.bucket) {
+    return null;
+  }
+
+  const key = `models/in-house/${artifact.modelType}/${modelVersionId}.json`;
+  const client = new S3Client({
+    region: options.region ?? process.env.AWS_REGION ?? 'us-west-2',
+  });
+
+  await client.send(
+    new PutObjectCommand({
+      Bucket: options.bucket,
+      Key: key,
+      Body: Buffer.from(JSON.stringify(artifact, null, 2), 'utf-8'),
+      ContentType: 'application/json',
+    })
+  );
+
+  return `s3://${options.bucket}/${key}`;
+}
+
+function averageNdcg(artifact: InHouseLinearModelArtifact): number | null {
+  const scores = [artifact.metrics.ndcgAt3, artifact.metrics.ndcgAt5].filter(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value)
+  );
+  if (scores.length === 0) {
+    return null;
+  }
+  return scores.reduce((sum, value) => sum + value, 0) / scores.length;
+}
+
+function normalizeMetrics(value: unknown): InHouseModelMetrics {
+  if (!value || typeof value !== 'object') {
+    return {
+      ndcgAt3: null,
+      ndcgAt5: null,
+      baselineNdcgAt3: null,
+      baselineNdcgAt5: null,
+      pairwiseAccuracy: null,
+      baselinePairwiseAccuracy: null,
+    };
+  }
+
+  const metrics = value as Record<string, unknown>;
+  return {
+    ndcgAt3: asNumber(metrics.ndcgAt3),
+    ndcgAt5: asNumber(metrics.ndcgAt5),
+    baselineNdcgAt3: asNumber(metrics.baselineNdcgAt3),
+    baselineNdcgAt5: asNumber(metrics.baselineNdcgAt5),
+    pairwiseAccuracy: asNumber(metrics.pairwiseAccuracy),
+    baselinePairwiseAccuracy: asNumber(metrics.baselinePairwiseAccuracy),
+  };
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}

--- a/apps/api/src/ml/premium-quality.ts
+++ b/apps/api/src/ml/premium-quality.ts
@@ -1,0 +1,143 @@
+import {
+  normalizeModelScore,
+  scoreFeatureVector,
+  type InHouseLinearModelArtifact,
+} from './in-house-models';
+import type {
+  ComplianceCheckResult,
+  PremiumInsightPayload,
+  RiskReviewDecision,
+} from '../premium/types';
+
+export const PREMIUM_FEATURE_NAMES = [
+  'f0_decision_score',
+  'f1_checks_norm',
+  'f2_clear_ratio',
+  'f3_conflict_ratio',
+  'f4_has_cost_totals',
+  'f5_live_weather_ratio',
+  'f6_has_report',
+] as const;
+
+export interface PremiumQualityFeatureInput {
+  decision: string | null;
+  checks: unknown;
+  costAnalysis: unknown;
+  sprayWindows: unknown;
+  report: unknown;
+}
+
+export function buildPremiumFeatureVector(
+  input: PremiumQualityFeatureInput
+): [number, number, number, number, number, number, number] {
+  const checks = toArray(input.checks);
+  const checkCount = checks.length;
+  const clearSignals = checks.filter((check) => check.result === 'clear_signal').length;
+  const conflicts = checks.filter((check) => check.result === 'potential_conflict').length;
+
+  const costAnalysis = toObject(input.costAnalysis);
+  const perAcre = toNumber(costAnalysis.perAcreTotalUsd) ?? 0;
+  const wholeField = toNumber(costAnalysis.wholeFieldTotalUsd) ?? 0;
+  const hasCostTotals = perAcre > 0 || wholeField > 0 ? 1 : 0;
+
+  const sprayWindows = toArray(input.sprayWindows);
+  const liveWindows = sprayWindows.filter((window) => {
+    const source = String(window.source ?? '').toLowerCase();
+    return source.length > 0 && source !== 'fallback';
+  }).length;
+
+  const report = toObject(input.report);
+  const hasReport = report.html || report.htmlUrl || report.pdfUrl ? 1 : 0;
+
+  const checksNorm = Math.min(1, checkCount / 6);
+  const clearRatio = checkCount > 0 ? clearSignals / checkCount : 0;
+  const conflictRatio = checkCount > 0 ? conflicts / checkCount : 0;
+  const liveWeatherRatio = sprayWindows.length > 0 ? liveWindows / sprayWindows.length : 0;
+
+  return [
+    decisionScore(input.decision),
+    checksNorm,
+    clearRatio,
+    conflictRatio,
+    hasCostTotals,
+    liveWeatherRatio,
+    hasReport,
+  ];
+}
+
+export function buildPremiumQualityCheck(params: {
+  artifact: InHouseLinearModelArtifact;
+  payload: Pick<PremiumInsightPayload, 'riskReview' | 'checks' | 'costAnalysis' | 'sprayWindows' | 'report'>;
+}): ComplianceCheckResult {
+  const features = buildPremiumFeatureVector({
+    decision: params.payload.riskReview,
+    checks: params.payload.checks,
+    costAnalysis: params.payload.costAnalysis,
+    sprayWindows: params.payload.sprayWindows,
+    report: params.payload.report,
+  });
+  const rawScore = scoreFeatureVector(features, params.artifact);
+  const normalizedScore = normalizeModelScore(rawScore, params.artifact);
+  const result = qualityBandToDecision(normalizedScore);
+
+  return {
+    id: 'premium_quality_confidence',
+    title: 'Premium Coverage Confidence',
+    result,
+    severity: 'soft',
+    message: qualityMessage(normalizedScore, result),
+    ruleVersion: 'premium-quality-model-v1',
+    sourceVersion: params.artifact.backend,
+    evidence: {
+      qualityScore: normalizedScore,
+      rawScore,
+      trainedAt: params.artifact.trainedAt,
+      ndcgAt3: params.artifact.metrics.ndcgAt3,
+      ndcgAt5: params.artifact.metrics.ndcgAt5,
+      pairwiseAccuracy: params.artifact.metrics.pairwiseAccuracy,
+    },
+  };
+}
+
+function qualityBandToDecision(score: number): RiskReviewDecision {
+  if (score >= 0.75) {
+    return 'clear_signal';
+  }
+  if (score >= 0.45) {
+    return 'needs_manual_verification';
+  }
+  return 'potential_conflict';
+}
+
+function qualityMessage(score: number, decision: RiskReviewDecision): string {
+  const pct = Math.round(score * 100);
+  if (decision === 'clear_signal') {
+    return `Premium package quality is strong (${pct}/100) with good evidence coverage across compliance, cost, weather, and report output.`;
+  }
+  if (decision === 'needs_manual_verification') {
+    return `Premium package quality is moderate (${pct}/100). Some support signals are present, but cost or weather coverage may still need manual verification.`;
+  }
+  return `Premium package quality is weak (${pct}/100). Missing pricing, fallback weather, or incomplete report support reduces confidence in the premium output.`;
+}
+
+function decisionScore(decision: string | null): number {
+  if (decision === 'clear_signal') return 0.9;
+  if (decision === 'potential_conflict') return 0.35;
+  if (decision === 'needs_manual_verification') return 0.5;
+  return 0.4;
+}
+
+function toArray(raw: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object');
+}
+
+function toObject(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object') return {};
+  return raw as Record<string, unknown>;
+}
+
+function toNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/apps/api/src/ml/reranker.ts
+++ b/apps/api/src/ml/reranker.ts
@@ -1,12 +1,11 @@
 /**
- * SageMaker Learning-to-Rank reranker.
+ * In-house retrieval reranker.
  *
- * Calls a deployed LightGBM LambdaRank endpoint to re-score retrieval
- * candidates using a model trained on user feedback signals.
- * Falls back gracefully to the original hybrid-ranker order when the
- * endpoint is unconfigured or unavailable.
+ * Scores retrieval candidates with a locally computed linear model trained
+ * from feedback data. Falls back to the default weight set when no deployed
+ * artifact exists.
  *
- * Feature vector (must match FEATURE_COLS in train-ranker.py and export-training-data.ts):
+ * Feature vector (must match training export/build logic):
  *   f0: similarity       — vector similarity score (0–1)
  *   f1: rank_score       — hybrid rank score (0–1)
  *   f2: source_authority — encoded source authority float
@@ -14,13 +13,14 @@
  *   f4: crop_match       — 1 if caller crop ∈ chunk metadata.crops else 0
  *   f5: term_density     — fraction of query terms found in chunk topics
  *   f6: chunk_pos        — normalised chunk position (0–1, capped at position 10)
- *
- * Environment variables:
- *   SAGEMAKER_ENDPOINT_NAME  — endpoint name; leave unset to disable reranking
- *   AWS_REGION               — AWS region (defaults to us-east-1)
  */
 
 import type { RankedCandidate, SourceAuthorityType } from '../rag/types';
+import {
+  getDefaultModelArtifact,
+  scoreFeatureVector,
+  type InHouseLinearModelArtifact,
+} from './in-house-models';
 
 const AUTHORITY_SCORES: Record<SourceAuthorityType, number> = {
   GOVERNMENT: 1.0,
@@ -34,17 +34,22 @@ const AUTHORITY_SCORES: Record<SourceAuthorityType, number> = {
 export interface RerankContext {
   crop?: string;
   queryTerms?: string[];
+  model?: InHouseLinearModelArtifact | null;
 }
 
+export const RETRIEVAL_FEATURE_NAMES = [
+  'f0_similarity',
+  'f1_rank_score',
+  'f2_authority',
+  'f3_source_boost',
+  'f4_crop_match',
+  'f5_term_density',
+  'f6_chunk_pos',
+] as const;
+
 /**
- * Re-rank candidates using the SageMaker LambdaRank endpoint.
- *
- * Returns `null` when:
- * - SAGEMAKER_ENDPOINT_NAME is not set (reranker disabled)
- * - candidates list is empty
- * - the endpoint call fails for any reason
- *
- * The caller must fall back to the original ranked order in all null cases.
+ * Re-rank candidates using the deployed in-house artifact, or the default
+ * fallback model when no artifact is available.
  */
 export async function rerank(
   candidates: RankedCandidate[],
@@ -54,158 +59,52 @@ export async function rerank(
     return null;
   }
 
-  const endpointName = process.env.SAGEMAKER_ENDPOINT_NAME?.trim();
-  if (!endpointName || candidates.length === 0) {
+  if (candidates.length === 0) {
     return null;
   }
 
-  const region = process.env.AWS_REGION?.trim() || 'us-east-1';
-  const payload = buildCsvPayload(candidates, context);
+  const model =
+    context.model ?? getDefaultModelArtifact('lambdarank', [...RETRIEVAL_FEATURE_NAMES]);
+  const scored = candidates.map((candidate) => ({
+    candidate,
+    score: scoreFeatureVector(buildFeatureVector(candidate, context), model),
+  }));
 
-  try {
-    // Dynamic import keeps @aws-sdk/client-sagemaker-runtime out of the
-    // cold-start bundle when the reranker is not configured.
-    const { SageMakerRuntimeClient, InvokeEndpointCommand } = await import(
-      '@aws-sdk/client-sagemaker-runtime'
-    );
-
-    const client = new SageMakerRuntimeClient({ region });
-    const command = new InvokeEndpointCommand({
-      EndpointName: endpointName,
-      ContentType: 'text/csv',
-      Accept: 'text/csv',
-      Body: Buffer.from(payload, 'utf-8'),
-    });
-    const timeoutMs = parsePositiveInt(
-      process.env.RERANKER_TIMEOUT_MS,
-      4_000
-    );
-    const response = await withTimeout(
-      client.send(command),
-      timeoutMs,
-      `SageMaker reranker timeout after ${timeoutMs}ms`
-    );
-
-    // Body is a Uint8ArrayBlobAdapter in the Node.js SDK runtime
-    const responseBody = response.Body
-      ? await (response.Body as unknown as { transformToString(): Promise<string> }).transformToString()
-      : '';
-
-    const scores = parseScores(responseBody, candidates.length);
-    if (!scores) {
-      return null;
-    }
-
-    return applyScores(candidates, scores);
-  } catch (error) {
-    console.warn('[reranker] SageMaker call failed — falling back to hybrid ranking', {
-      endpoint: endpointName,
-      error: (error as Error).message,
-    });
-    return null;
-  }
-}
-
-async function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  message: string
-): Promise<T> {
-  let timer: NodeJS.Timeout | null = null;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
-  });
-  try {
-    return await Promise.race([promise, timeoutPromise]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
-function parsePositiveInt(raw: string | undefined, fallback: number): number {
-  const parsed = Number.parseInt(raw ?? '', 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-  return parsed;
+  return scored
+    .sort((left, right) => right.score - left.score)
+    .map(({ candidate, score }) => ({
+      ...candidate,
+      rankScore: score,
+    }));
 }
 
 /**
- * Build a CSV payload: one line per candidate with all 7 features.
- * Row order must be preserved; scores come back in the same order.
+ * Build the 7-feature vector for training/runtime scoring.
  */
-function buildCsvPayload(candidates: RankedCandidate[], context: RerankContext): string {
+export function buildFeatureVector(
+  candidate: RankedCandidate,
+  context: Pick<RerankContext, 'crop' | 'queryTerms'>
+): number[] {
   const queryCrop = (context.crop ?? '').toLowerCase().trim();
   const queryTerms = (context.queryTerms ?? []).map((t) => t.toLowerCase());
+  const f0 = clamp(candidate.similarity, 0, 1);
+  const f1 = clamp(candidate.rankScore, 0, 1);
+  const f2 = AUTHORITY_SCORES[candidate.sourceType] ?? AUTHORITY_SCORES.OTHER;
+  const f3 = clamp(candidate.sourceBoost ?? 0, -0.1, 0.25);
 
-  return candidates
-    .map((candidate) => {
-      const f0 = clamp(candidate.similarity, 0, 1).toFixed(6);
-      const f1 = clamp(candidate.rankScore, 0, 1).toFixed(6);
-      const f2 = (AUTHORITY_SCORES[candidate.sourceType] ?? AUTHORITY_SCORES.OTHER).toFixed(2);
-      const f3 = clamp(candidate.sourceBoost ?? 0, -0.1, 0.25).toFixed(4);
+  const chunkCrops = (candidate.metadata?.crops ?? []).map((crop) => crop.toLowerCase());
+  const f4 = queryCrop.length > 0 && chunkCrops.includes(queryCrop) ? 1 : 0;
 
-      // f4: crop match
-      const chunkCrops = (candidate.metadata?.crops ?? []).map((c) => c.toLowerCase());
-      const f4 = queryCrop.length > 0 && chunkCrops.includes(queryCrop) ? '1' : '0';
+  const chunkTopics = (candidate.metadata?.topics ?? []).map((topic) => topic.toLowerCase());
+  const f5 =
+    queryTerms.length > 0
+      ? queryTerms.filter(
+          (term) => chunkTopics.includes(term) || chunkTopics.some((topic) => topic.includes(term)),
+        ).length / queryTerms.length
+      : 0;
 
-      // f5: term density
-      const chunkTopics = (candidate.metadata?.topics ?? []).map((t) => t.toLowerCase());
-      const termDensity =
-        queryTerms.length > 0
-          ? queryTerms.filter(
-              (t) => chunkTopics.includes(t) || chunkTopics.some((ct) => ct.includes(t)),
-            ).length / queryTerms.length
-          : 0;
-      const f5 = termDensity.toFixed(4);
-
-      // f6: normalised chunk position
-      const f6 = Math.min(1, (candidate.metadata?.position ?? 0) / 10).toFixed(4);
-
-      return `${f0},${f1},${f2},${f3},${f4},${f5},${f6}`;
-    })
-    .join('\n');
-}
-
-/**
- * Parse newline-separated score values returned by the endpoint.
- * Returns null on any parse error so the caller can fall back.
- */
-function parseScores(body: string, expectedCount: number): number[] | null {
-  const lines = body
-    .split(/[\n,]+/g)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  if (lines.length !== expectedCount) {
-    console.warn('[reranker] score count mismatch', {
-      expected: expectedCount,
-      received: lines.length,
-    });
-    return null;
-  }
-
-  const scores = lines.map((line) => Number(line));
-  if (scores.some((score) => !Number.isFinite(score))) {
-    console.warn('[reranker] non-numeric value in endpoint response');
-    return null;
-  }
-
-  return scores;
-}
-
-/**
- * Attach predicted scores to candidates and re-sort descending.
- */
-function applyScores(candidates: RankedCandidate[], scores: number[]): RankedCandidate[] {
-  return candidates
-    .map((candidate, index) => ({
-      ...candidate,
-      rankScore: scores[index]!,
-    }))
-    .sort((a, b) => b.rankScore - a.rankScore);
+  const f6 = Math.min(1, (candidate.metadata?.position ?? 0) / 10);
+  return [f0, f1, f2, f3, f4, f5, f6];
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/apps/api/src/ml/training/retrain-premium-trigger.ts
+++ b/apps/api/src/ml/training/retrain-premium-trigger.ts
@@ -2,14 +2,19 @@ import type { EventBridgeHandler } from 'aws-lambda';
 import { Pool } from 'pg';
 import { resolvePoolSslConfig, sanitizeDatabaseUrlForPool } from '../../lib/store';
 import { recordPipelineEvent } from '../../lib/pipeline-events';
+import {
+  getDefaultModelArtifact,
+  trainLinearRankingModel,
+  type RankingExample,
+} from '../in-house-models';
+import { PREMIUM_FEATURE_NAMES, buildPremiumFeatureVector } from '../premium-quality';
+import { deployInHouseModelArtifact, retireModelVersion } from '../model-registry';
 
 const DEFAULT_MIN_PREMIUM_FEEDBACK = 30;
 
 interface PremiumRetrainTriggerEvent {
   force?: boolean;
 }
-
-type TrainingBackend = 'lightgbm_custom' | 'xgboost_builtin';
 
 interface PremiumTrainingRow {
   recommendation_id: string;
@@ -39,36 +44,6 @@ function getPool(): Pool {
   return pool;
 }
 
-function toArray(raw: unknown): Array<Record<string, unknown>> {
-  if (!Array.isArray(raw)) return [];
-  return raw.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object');
-}
-
-function toObject(raw: unknown): Record<string, unknown> {
-  if (!raw || typeof raw !== 'object') return {};
-  return raw as Record<string, unknown>;
-}
-
-function toNumber(value: unknown): number | null {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function resolveTrainingBackend(raw: string | undefined): TrainingBackend {
-  const normalized = (raw ?? '').trim().toLowerCase();
-  if (normalized === 'xgboost' || normalized === 'xgboost_builtin' || normalized === 'builtin') {
-    return 'xgboost_builtin';
-  }
-  return 'lightgbm_custom';
-}
-
-function decisionScore(decision: string | null): number {
-  if (decision === 'clear_signal') return 0.9;
-  if (decision === 'potential_conflict') return 0.35;
-  if (decision === 'needs_manual_verification') return 0.5;
-  return 0.4;
-}
-
 function computeFeedbackSignal(row: PremiumTrainingRow): number {
   if (row.outcome_success === true) return 2;
   if (row.outcome_success === false) return -2;
@@ -90,74 +65,11 @@ function computeFeedbackSignal(row: PremiumTrainingRow): number {
   return Math.max(-2, Math.min(2, signal));
 }
 
-function featureVector(row: PremiumTrainingRow): [number, number, number, number, number, number, number] {
-  const checks = toArray(row.checks);
-  const checkCount = checks.length;
-  const clearSignals = checks.filter((check) => check.result === 'clear_signal').length;
-  const conflicts = checks.filter((check) => check.result === 'potential_conflict').length;
-
-  const costAnalysis = toObject(row.cost_analysis);
-  const perAcre = toNumber(costAnalysis.perAcreTotalUsd) ?? 0;
-  const wholeField = toNumber(costAnalysis.wholeFieldTotalUsd) ?? 0;
-  const hasCostTotals = perAcre > 0 || wholeField > 0 ? 1 : 0;
-
-  const sprayWindows = toArray(row.spray_windows);
-  const liveWindows = sprayWindows.filter((window) => {
-    const source = String(window.source ?? '').toLowerCase();
-    return source.length > 0 && source !== 'fallback';
-  }).length;
-
-  const report = toObject(row.report);
-  const hasReport = report.htmlUrl || report.pdfUrl ? 1 : 0;
-
-  const checksNorm = Math.min(1, checkCount / 6);
-  const clearRatio = checkCount > 0 ? clearSignals / checkCount : 0;
-  const conflictRatio = checkCount > 0 ? conflicts / checkCount : 0;
-  const liveWeatherRatio = sprayWindows.length > 0 ? liveWindows / sprayWindows.length : 0;
-
-  return [
-    decisionScore(row.decision),
-    checksNorm,
-    clearRatio,
-    conflictRatio,
-    hasCostTotals,
-    liveWeatherRatio,
-    hasReport,
-  ];
-}
-
-function serializeTrainingRow(
-  qid: string,
-  label: 0 | 1 | 2,
-  features: [number, number, number, number, number, number, number],
-  backend: TrainingBackend,
-): string {
-  const featureCsv =
-    `${features[0].toFixed(6)},${features[1].toFixed(6)},${features[2].toFixed(6)},` +
-    `${features[3].toFixed(6)},${features[4].toFixed(6)},${features[5].toFixed(6)},${features[6].toFixed(6)}`;
-  if (backend === 'xgboost_builtin') {
-    return `${label},${featureCsv}`;
-  }
-  return `${qid},${label},${featureCsv}`;
-}
-
-async function exportPremiumTrainingDataToS3(
+async function buildPremiumTrainingExamples(
   db: Pool,
-  bucket: string,
-  region: string,
-  lastTrainedAt: Date,
-  backend: TrainingBackend
-): Promise<{ s3PrefixUri: string; rowCount: number }> {
-  const { S3Client, PutObjectCommand } = await import('@aws-sdk/client-s3');
-  const s3 = new S3Client({ region });
-
-  const csvLines: string[] =
-    backend === 'xgboost_builtin'
-      ? []
-      : [
-          'qid,label,f0_similarity,f1_rank_score,f2_authority,f3_source_boost,f4_crop_match,f5_term_density,f6_chunk_pos',
-        ];
-
+  lastTrainedAt: Date
+): Promise<RankingExample[]> {
+  const examples: RankingExample[] = [];
   const PAGE_SIZE = 500;
   let offset = 0;
 
@@ -185,43 +97,40 @@ async function exportPremiumTrainingDataToS3(
       [lastTrainedAt.toISOString(), PAGE_SIZE, offset]
     );
 
-    if (result.rows.length === 0) break;
+    if (result.rows.length === 0) {
+      break;
+    }
 
     for (const row of result.rows) {
       const signal = computeFeedbackSignal(row);
       const label: 0 | 1 | 2 = signal > 0 ? 2 : signal < 0 ? 0 : 1;
-      const features = featureVector(row);
-      csvLines.push(serializeTrainingRow(row.recommendation_id, label, features, backend));
+      const features = buildPremiumFeatureVector({
+        decision: row.decision,
+        checks: row.checks,
+        costAnalysis: row.cost_analysis,
+        sprayWindows: row.spray_windows,
+        report: row.report,
+      });
+      examples.push({
+        qid: row.recommendation_id,
+        label,
+        features: [...features],
+      });
 
-      // Add a simple baseline candidate per recommendation so each qid has competition.
-      csvLines.push(
-        serializeTrainingRow(row.recommendation_id, 0, [0, 0, 0, 0, 0, 0, 0], backend)
-      );
+      examples.push({
+        qid: row.recommendation_id,
+        label: 0,
+        features: [0, 0, 0, 0, 0, 0, 0],
+      });
     }
 
     offset += PAGE_SIZE;
-    if (result.rows.length < PAGE_SIZE) break;
+    if (result.rows.length < PAGE_SIZE) {
+      break;
+    }
   }
 
-  const rowCount = csvLines.length - (backend === 'xgboost_builtin' ? 0 : 1);
-  if (rowCount <= 0) {
-    throw new Error('No premium training rows were exported');
-  }
-
-  const s3Key = 'training-data/premium-quality/latest/training.csv';
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: s3Key,
-      Body: Buffer.from(csvLines.join('\n'), 'utf-8'),
-      ContentType: 'text/csv',
-    })
-  );
-
-  return {
-    s3PrefixUri: `s3://${bucket}/training-data/premium-quality/latest/`,
-    rowCount,
-  };
+  return examples;
 }
 
 async function hasActiveTrainingRun(db: Pool): Promise<boolean> {
@@ -302,31 +211,6 @@ export const handler: EventBridgeHandler<
     return;
   }
 
-  const bucket = process.env.S3_TRAINING_BUCKET;
-  const roleArn = process.env.SAGEMAKER_ROLE_ARN;
-  const trainingImage =
-    process.env.SAGEMAKER_PREMIUM_TRAINING_IMAGE || process.env.SAGEMAKER_TRAINING_IMAGE;
-  const trainingBackend = resolveTrainingBackend(
-    process.env.SAGEMAKER_PREMIUM_TRAINING_BACKEND ?? process.env.SAGEMAKER_TRAINING_BACKEND
-  );
-  const jobBaseName =
-    process.env.SAGEMAKER_PREMIUM_TRAINING_JOB_NAME ?? 'cropcopilot-premium-quality';
-  const region = process.env.AWS_REGION ?? 'us-east-1';
-
-  if (!bucket || !roleArn || !trainingImage) {
-    await recordPipelineEvent(db, {
-      pipeline: 'learning',
-      stage: 'premium_retrain_check',
-      severity: 'warn',
-      message:
-        'Skipped premium retrain because S3_TRAINING_BUCKET / SAGEMAKER_ROLE_ARN / SAGEMAKER_PREMIUM_TRAINING_IMAGE is not fully configured.',
-      metadata: {
-        modelType: 'premium_quality',
-      },
-    });
-    return;
-  }
-
   const versionResult = await db.query<{ id: string }>(
     `
       INSERT INTO "MLModelVersion" ("modelType", "feedbackCount", status, "createdAt", "trainedAt")
@@ -339,134 +223,50 @@ export const handler: EventBridgeHandler<
   if (!modelVersionId) throw new Error('Failed to create premium MLModelVersion row');
 
   try {
-    const exportResult = await exportPremiumTrainingDataToS3(
-      db,
-      bucket,
-      region,
-      lastTrainedAt,
-      trainingBackend
-    );
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-    const jobName = `${jobBaseName}-${timestamp}`;
-    const s3OutputPath = `s3://${bucket}/models/${jobName}/`;
-
-    const { SageMakerClient, CreateTrainingJobCommand } = await import(
-      '@aws-sdk/client-sagemaker'
-    );
-    const sm = new SageMakerClient({ region });
-    const channelName = trainingBackend === 'xgboost_builtin' ? 'train' : 'training';
-
-    const hyperParameters: Record<string, string> = {};
-    if (trainingBackend === 'xgboost_builtin') {
-      hyperParameters.objective = process.env.XGBOOST_OBJECTIVE ?? 'reg:squarederror';
-      hyperParameters.eval_metric = process.env.XGBOOST_EVAL_METRIC ?? 'rmse';
-      hyperParameters.num_round = process.env.XGBOOST_NUM_ROUND ?? '220';
-      hyperParameters.max_depth = process.env.XGBOOST_MAX_DEPTH ?? '6';
-      hyperParameters.eta = process.env.XGBOOST_ETA ?? '0.1';
-      hyperParameters.subsample = process.env.XGBOOST_SUBSAMPLE ?? '0.85';
-      hyperParameters.colsample_bytree = process.env.XGBOOST_COLSAMPLE_BYTREE ?? '0.85';
-    } else {
-      hyperParameters.model_version_id = modelVersionId;
-      hyperParameters.training_domain = 'premium_quality';
+    const examples = await buildPremiumTrainingExamples(db, lastTrainedAt);
+    if (examples.length === 0) {
+      throw new Error('No premium training rows were exported');
     }
 
-    await sm.send(
-      new CreateTrainingJobCommand({
-        TrainingJobName: jobName,
-        AlgorithmSpecification: {
-          TrainingImage: trainingImage,
-          TrainingInputMode: 'File',
-        },
-        RoleArn: roleArn,
-        InputDataConfig: [
-          {
-            ChannelName: channelName,
-            DataSource: {
-              S3DataSource: {
-                S3DataType: 'S3Prefix',
-                S3Uri: exportResult.s3PrefixUri,
-                S3DataDistributionType: 'FullyReplicated',
-              },
-            },
-            ContentType: 'text/csv',
-          },
-        ],
-        OutputDataConfig: {
-          S3OutputPath: s3OutputPath,
-        },
-        ResourceConfig: {
-          InstanceType: 'ml.m5.large',
-          InstanceCount: 1,
-          VolumeSizeInGB: 10,
-        },
-        StoppingCondition: {
-          MaxRuntimeInSeconds: 3600,
-        },
-        HyperParameters: hyperParameters,
-        Tags: [
-          { Key: 'Project', Value: 'CropCopilot' },
-          { Key: 'ModelVersionId', Value: modelVersionId },
-          { Key: 'ModelType', Value: 'premium_quality' },
-          { Key: 'TrainingBackend', Value: trainingBackend },
-        ],
-      })
-    );
+    const defaultArtifact = getDefaultModelArtifact('premium_quality', [...PREMIUM_FEATURE_NAMES]);
+    const artifact = trainLinearRankingModel({
+      modelType: 'premium_quality',
+      featureNames: [...PREMIUM_FEATURE_NAMES],
+      examples,
+      defaultWeights: defaultArtifact.featureWeights,
+    });
 
-    await db.query(
-      `UPDATE "MLModelVersion" SET "s3Uri" = $1, "updatedAt" = NOW() WHERE id = $2`,
-      [`${s3OutputPath}output/model.tar.gz`, modelVersionId]
-    );
+    const deployment = await deployInHouseModelArtifact(db, {
+      modelVersionId,
+      artifact,
+      bucket: process.env.S3_TRAINING_BUCKET ?? null,
+      region: process.env.AWS_REGION ?? 'us-west-2',
+    });
 
     await recordPipelineEvent(db, {
       pipeline: 'learning',
-      stage: 'premium_retrain_submit',
+      stage: 'premium_retrain_deploy',
       severity: 'info',
-      message: `Submitted premium training job ${jobName}.`,
+      message: 'Deployed premium quality artifact from in-house trainer.',
       metadata: {
         modelType: 'premium_quality',
-        jobName,
         modelVersionId,
-        samples: newFeedbackCount,
-        trainingRows: exportResult.rowCount,
-        trainingBackend,
+        feedbackCount: newFeedbackCount,
+        trainingRows: examples.length,
+        backend: artifact.backend,
+        ndcgAt3: artifact.metrics.ndcgAt3,
+        ndcgAt5: artifact.metrics.ndcgAt5,
+        pairwiseAccuracy: artifact.metrics.pairwiseAccuracy,
+        s3Uri: deployment.s3Uri,
       },
     });
   } catch (error) {
-    const message = (error as Error).message;
-    const isQuotaBlocked =
-      (error as { name?: string }).name === 'ResourceLimitExceeded' ||
-      /resource.?limit.?exceeded/i.test(message) ||
-      /training job usage/i.test(message);
-
-    if (isQuotaBlocked) {
-      await db.query(
-        `UPDATE "MLModelVersion" SET status = 'retired', "updatedAt" = NOW() WHERE id = $1`,
-        [modelVersionId]
-      );
-      await recordPipelineEvent(db, {
-        pipeline: 'learning',
-        stage: 'premium_retrain_submit',
-        severity: 'warn',
-        message:
-          'Premium retrain skipped because SageMaker training quota is unavailable in this account/region.',
-        metadata: {
-          modelType: 'premium_quality',
-          modelVersionId,
-          reason: message,
-        },
-      });
-      return;
-    }
-
-    await db.query(
-      `UPDATE "MLModelVersion" SET status = 'retired', "updatedAt" = NOW() WHERE id = $1`,
-      [modelVersionId]
-    );
+    await retireModelVersion(db, modelVersionId);
     await recordPipelineEvent(db, {
       pipeline: 'learning',
-      stage: 'premium_retrain_submit',
+      stage: 'premium_retrain_deploy',
       severity: 'error',
-      message: `Premium retrain failed: ${message}`,
+      message: `Premium retrain failed: ${(error as Error).message}`,
       metadata: {
         modelType: 'premium_quality',
         modelVersionId,

--- a/apps/api/src/ml/training/retrain-trigger.ts
+++ b/apps/api/src/ml/training/retrain-trigger.ts
@@ -1,35 +1,52 @@
 /**
- * Automated retraining trigger (EventBridge Lambda)
+ * Automated in-house retraining trigger.
  *
- * Runs on a schedule (e.g. nightly at 2 AM UTC).
- * Checks if enough new Feedback rows have accumulated since the last
- * training run. If so:
- *   1. Exports training data from Postgres to S3 (CSV)
- *   2. Kicks off a SageMaker Training Job using the exported CSV
- *   3. Records the new version in MLModelVersion table
+ * Runs on a schedule or from feedback-triggered queue work. When enough new
+ * feedback exists, it:
+ *   1. Builds retrieval ranking examples from RetrievalAudit + Feedback
+ *   2. Trains an in-house linear ranking artifact
+ *   3. Deploys that artifact by updating MLModelVersion and persisting JSON
  *
- * Environment variables:
- *   DATABASE_URL                — Postgres connection string
- *   RETRAINING_MIN_FEEDBACK     — Minimum new Feedback rows before retraining (default 50)
- *   S3_TRAINING_BUCKET          — S3 bucket for training data export and model artifacts
- *   SAGEMAKER_TRAINING_JOB_NAME — Base name for training jobs (default: cropcopilot-ltr)
- *   SAGEMAKER_TRAINING_IMAGE    — ECR image URI for the LightGBM training container
- *   SAGEMAKER_ROLE_ARN          — IAM role ARN for SageMaker jobs
- *   AWS_REGION                  — AWS region (defaults to us-east-1)
+ * No SageMaker training job or realtime endpoint is involved.
  */
 
 import type { EventBridgeHandler } from 'aws-lambda';
 import { Pool } from 'pg';
 import { resolvePoolSslConfig, sanitizeDatabaseUrlForPool } from '../../lib/store';
 import { recordPipelineEvent } from '../../lib/pipeline-events';
+import { buildFeatureVector, RETRIEVAL_FEATURE_NAMES } from '../reranker';
+import {
+  getDefaultModelArtifact,
+  trainLinearRankingModel,
+  type RankingExample,
+} from '../in-house-models';
+import { deployInHouseModelArtifact, retireModelVersion } from '../model-registry';
 
 const DEFAULT_MIN_FEEDBACK = 50;
 
 interface RetrainTriggerEvent {
-  force?: boolean; // Skip the feedback count check and always retrain
+  force?: boolean;
 }
 
-type TrainingBackend = 'lightgbm_custom' | 'xgboost_builtin';
+interface ChunkEntry {
+  id: string;
+  sourceId: string | null;
+  similarity: number;
+  rankScore: number;
+  sourceType: string;
+  cited: boolean;
+  metadata?: { crops?: string[]; topics?: string[]; position?: number };
+}
+
+interface TrainingRow {
+  recommendation_id: string;
+  candidate_chunks: unknown;
+  query_topics: unknown;
+  query_crop: string | null;
+  helpful: boolean | null;
+  rating: number | null;
+  outcome_success: boolean | null;
+}
 
 let pool: Pool | null = null;
 
@@ -59,27 +76,6 @@ async function hasActiveTrainingRun(db: Pool): Promise<boolean> {
   return Number(active.rows[0]?.count ?? 0) > 0;
 }
 
-// ── Training data export helpers ─────────────────────────────────────────────
-
-const AUTHORITY_SCORES: Record<string, number> = {
-  GOVERNMENT: 1.0,
-  UNIVERSITY_EXTENSION: 0.9,
-  RESEARCH_PAPER: 0.85,
-  MANUFACTURER: 0.6,
-  RETAILER: 0.4,
-  OTHER: 0.5,
-};
-
-interface ChunkEntry {
-  id: string;
-  sourceId: string | null;
-  similarity: number;
-  rankScore: number;
-  sourceType: string;
-  cited: boolean;
-  metadata?: { crops?: string[]; topics?: string[]; position?: number };
-}
-
 function parseChunks(raw: unknown): ChunkEntry[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -96,12 +92,12 @@ function parseChunks(raw: unknown): ChunkEntry[] {
           ? (item['metadata'] as ChunkEntry['metadata'])
           : undefined,
     }))
-    .filter((c) => c.id.length > 0);
+    .filter((chunk) => chunk.id.length > 0);
 }
 
 function parseTopics(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
-  return raw.filter((t): t is string => typeof t === 'string').map((t) => t.toLowerCase());
+  return raw.filter((topic): topic is string => typeof topic === 'string').map((topic) => topic.toLowerCase());
 }
 
 function computeFeedbackSignal(params: {
@@ -129,67 +125,25 @@ function computeLabel(cited: boolean, feedbackSignal: number): 0 | 1 | 2 {
   return 1;
 }
 
-function resolveTrainingBackend(raw: string | undefined): TrainingBackend {
-  const normalized = (raw ?? '').trim().toLowerCase();
-  if (normalized === 'xgboost' || normalized === 'xgboost_builtin' || normalized === 'builtin') {
-    return 'xgboost_builtin';
-  }
-  return 'lightgbm_custom';
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.min(max, Math.max(min, value));
-}
-
-/**
- * Export training data from Postgres directly to S3 as a CSV file.
- * Returns the S3 URI of the uploaded file.
- */
-async function exportTrainingDataToS3(
-  db: Pool,
-  bucket: string,
-  region: string,
-  backend: TrainingBackend,
-): Promise<{ s3PrefixUri: string; rowCount: number }> {
-  const { S3Client, PutObjectCommand } = await import('@aws-sdk/client-s3');
-  const s3 = new S3Client({ region });
-
-  // Pre-load source boosts for the feature vector
+async function buildRetrievalTrainingExamples(db: Pool): Promise<RankingExample[]> {
   const boostResult = await db.query<{ source_id: string; boost: number }>(
     `SELECT "sourceId" AS source_id, boost FROM "SourceBoost"`,
   );
-  const boostBySourceId = new Map<string, number>(
-    boostResult.rows.map((r) => [r.source_id, r.boost]),
-  );
+  const boostBySourceId = new Map<string, number>(boostResult.rows.map((row) => [row.source_id, row.boost]));
 
-  const csvLines: string[] =
-    backend === 'xgboost_builtin'
-      ? []
-      : [
-          'qid,label,f0_similarity,f1_rank_score,f2_authority,f3_source_boost,f4_crop_match,f5_term_density,f6_chunk_pos',
-        ];
-
+  const examples: RankingExample[] = [];
   const PAGE_SIZE = 500;
   let offset = 0;
 
   while (true) {
-    const result = await db.query<{
-      recommendation_id: string;
-      candidate_chunks: unknown;
-      query_topics: unknown;
-      query_crop: string | null;
-      helpful: boolean | null;
-      rating: number | null;
-      outcome_success: boolean | null;
-    }>(
+    const result = await db.query<TrainingRow>(
       `SELECT COALESCE(ra."recommendationId", resolved.id) AS recommendation_id,
-              ra."candidateChunks"  AS candidate_chunks,
-              ra.topics             AS query_topics,
-              i.crop                AS query_crop,
+              ra."candidateChunks" AS candidate_chunks,
+              ra.topics AS query_topics,
+              i.crop AS query_crop,
               f.helpful,
               f.rating,
-              f."outcomeSuccess"    AS outcome_success
+              f."outcomeSuccess" AS outcome_success
        FROM "RetrievalAudit" ra
        LEFT JOIN LATERAL (
          SELECT r.id
@@ -198,7 +152,7 @@ async function exportTrainingDataToS3(
          ORDER BY ABS(EXTRACT(EPOCH FROM (r."createdAt" - ra."createdAt"))), r."createdAt" DESC
          LIMIT 1
        ) resolved ON TRUE
-       LEFT JOIN "Input"    i ON i.id = ra."inputId"
+       LEFT JOIN "Input" i ON i.id = ra."inputId"
        INNER JOIN "Feedback" f ON f."recommendationId" = COALESCE(ra."recommendationId", resolved.id)
        WHERE COALESCE(ra."recommendationId", resolved.id) IS NOT NULL
        ORDER BY ra."createdAt" DESC
@@ -206,86 +160,66 @@ async function exportTrainingDataToS3(
       [PAGE_SIZE, offset],
     );
 
-    if (result.rows.length === 0) break;
+    if (result.rows.length === 0) {
+      break;
+    }
 
     for (const row of result.rows) {
       const chunks = parseChunks(row.candidate_chunks);
-      if (chunks.length === 0) continue;
+      if (chunks.length === 0) {
+        continue;
+      }
 
-      const signal = computeFeedbackSignal({
+      const feedbackSignal = computeFeedbackSignal({
         helpful: row.helpful,
         rating: row.rating,
         outcomeSuccess: row.outcome_success,
       });
-
-      const queryTopics = parseTopics(row.query_topics);
-      const queryCrop = (row.query_crop ?? '').toLowerCase().trim();
+      const queryTerms = parseTopics(row.query_topics);
+      const crop = row.query_crop ?? undefined;
 
       for (const chunk of chunks) {
-        const label = computeLabel(chunk.cited, signal);
-        const authority = AUTHORITY_SCORES[chunk.sourceType] ?? AUTHORITY_SCORES['OTHER']!;
-        const sourceBoost = clamp(boostBySourceId.get(chunk.sourceId ?? '') ?? 0, -0.1, 0.25);
-        const similarity = clamp(chunk.similarity, 0, 1);
-        const rankScore = clamp(chunk.rankScore, 0, 1);
+        const label = computeLabel(chunk.cited, feedbackSignal);
+        const features = buildFeatureVector(
+          {
+            chunkId: chunk.id,
+            sourceId: chunk.sourceId ?? undefined,
+            content: '',
+            similarity: chunk.similarity,
+            rankScore: chunk.rankScore,
+            sourceType: chunk.sourceType as any,
+            sourceTitle: '',
+            sourceBoost: boostBySourceId.get(chunk.sourceId ?? '') ?? 0,
+            metadata: chunk.metadata,
+            scoreBreakdown: {
+              vector: chunk.similarity,
+              keyword: 0,
+              authority: 0,
+              metadata: 0,
+            },
+          },
+          {
+            crop,
+            queryTerms,
+          }
+        );
 
-        const chunkCrops = (chunk.metadata?.crops ?? []).map((c) => c.toLowerCase());
-        const cropMatch = queryCrop.length > 0 && chunkCrops.includes(queryCrop) ? 1 : 0;
-
-        const chunkTopics = (chunk.metadata?.topics ?? []).map((t) => t.toLowerCase());
-        const termDensity =
-          queryTopics.length > 0
-            ? queryTopics.filter(
-                (t) => chunkTopics.includes(t) || chunkTopics.some((ct) => ct.includes(t)),
-              ).length / queryTopics.length
-            : 0;
-
-        const chunkPos = Math.min(1, (chunk.metadata?.position ?? 0) / 10);
-
-        if (backend === 'xgboost_builtin') {
-          csvLines.push(
-            `${label},` +
-              `${similarity.toFixed(6)},${rankScore.toFixed(6)},` +
-              `${authority.toFixed(2)},${sourceBoost.toFixed(4)},` +
-              `${cropMatch},${termDensity.toFixed(4)},${chunkPos.toFixed(4)}`,
-          );
-        } else {
-          csvLines.push(
-            `${row.recommendation_id},${label},` +
-              `${similarity.toFixed(6)},${rankScore.toFixed(6)},` +
-              `${authority.toFixed(2)},${sourceBoost.toFixed(4)},` +
-              `${cropMatch},${termDensity.toFixed(4)},${chunkPos.toFixed(4)}`,
-          );
-        }
+        examples.push({
+          qid: row.recommendation_id,
+          label,
+          features,
+        });
       }
     }
 
     offset += PAGE_SIZE;
-    if (result.rows.length < PAGE_SIZE) break;
+    if (result.rows.length < PAGE_SIZE) {
+      break;
+    }
   }
 
-  const s3Key = 'training-data/latest/training.csv';
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: s3Key,
-      Body: Buffer.from(csvLines.join('\n'), 'utf-8'),
-      ContentType: 'text/csv',
-    }),
-  );
-
-  const rowCount = csvLines.length - (backend === 'xgboost_builtin' ? 0 : 1);
-  if (rowCount === 0) {
-    throw new Error('No lambdarank training rows were exported from RetrievalAudit + Feedback');
-  }
-  console.log(`[RetrainTrigger] Exported ${rowCount} training rows to s3://${bucket}/${s3Key}`);
-
-  return {
-    s3PrefixUri: `s3://${bucket}/training-data/latest/`,
-    rowCount,
-  };
+  return examples;
 }
-
-// ── Main handler ─────────────────────────────────────────────────────────────
 
 export const handler: EventBridgeHandler<
   'crop-copilot.ml.retrain.scheduled',
@@ -297,31 +231,21 @@ export const handler: EventBridgeHandler<
 
   const db = getPool();
 
-  // Find last successful training run
   const lastTrainedResult = await db.query<{ trained_at: Date }>(
     `SELECT "trainedAt" AS trained_at
      FROM "MLModelVersion"
      WHERE "modelType" = 'lambdarank' AND status = 'deployed'
      ORDER BY "trainedAt" DESC LIMIT 1`,
   );
-
   const lastTrainedAt = lastTrainedResult.rows[0]?.trained_at ?? new Date(0);
 
-  // Count new feedback since last training
   const feedbackResult = await db.query<{ count: string }>(
     `SELECT COUNT(*) AS count FROM "Feedback" WHERE "createdAt" > $1`,
     [lastTrainedAt.toISOString()],
   );
-
   const newFeedbackCount = Number(feedbackResult.rows[0]?.count ?? 0);
 
-  console.log(
-    `[RetrainTrigger] New feedback since ${lastTrainedAt.toISOString()}: ` +
-      `${newFeedbackCount} (threshold: ${minFeedback})`,
-  );
-
   if (!force && newFeedbackCount < minFeedback) {
-    console.log('[RetrainTrigger] Not enough new feedback — skipping retraining');
     await recordPipelineEvent(db, {
       pipeline: 'learning',
       stage: 'retrain_check',
@@ -339,7 +263,6 @@ export const handler: EventBridgeHandler<
   }
 
   if (await hasActiveTrainingRun(db)) {
-    console.log('[RetrainTrigger] Existing lambdarank training run in progress — skipping');
     await recordPipelineEvent(db, {
       pipeline: 'learning',
       stage: 'retrain_check',
@@ -352,32 +275,6 @@ export const handler: EventBridgeHandler<
     return;
   }
 
-  const bucket = process.env.S3_TRAINING_BUCKET;
-  const roleArn = process.env.SAGEMAKER_ROLE_ARN;
-  const trainingImage = process.env.SAGEMAKER_TRAINING_IMAGE;
-  const jobBaseName = process.env.SAGEMAKER_TRAINING_JOB_NAME ?? 'cropcopilot-ltr';
-  const trainingBackend = resolveTrainingBackend(process.env.SAGEMAKER_TRAINING_BACKEND);
-  const region = process.env.AWS_REGION ?? 'us-east-1';
-
-  if (!bucket || !roleArn || !trainingImage) {
-    console.warn(
-      '[RetrainTrigger] Missing S3_TRAINING_BUCKET / SAGEMAKER_ROLE_ARN / SAGEMAKER_TRAINING_IMAGE ' +
-        '— SageMaker job skipped. Set these env vars to enable automated retraining.',
-    );
-    await recordPipelineEvent(db, {
-      pipeline: 'learning',
-      stage: 'retrain_check',
-      severity: 'warn',
-      message:
-        'Skipped lambdarank retrain because S3_TRAINING_BUCKET / SAGEMAKER_ROLE_ARN / SAGEMAKER_TRAINING_IMAGE is not fully configured.',
-      metadata: {
-        modelType: 'lambdarank',
-      },
-    });
-    return;
-  }
-
-  // Create an MLModelVersion row with status=training
   const versionResult = await db.query<{ id: string }>(
     `INSERT INTO "MLModelVersion" ("modelType", "feedbackCount", status, "createdAt", "trainedAt")
      VALUES ('lambdarank', $1, 'training', NOW(), NOW())
@@ -389,142 +286,57 @@ export const handler: EventBridgeHandler<
   if (!modelVersionId) throw new Error('Failed to create MLModelVersion row');
 
   try {
-    // Step 1: Export training data from Postgres to S3
-    const exportResult = await exportTrainingDataToS3(
-      db,
-      bucket,
-      region,
-      trainingBackend,
-    );
-
-    // Step 2: Submit SageMaker training job
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-    const jobName = `${jobBaseName}-${timestamp}`;
-    const s3OutputPath = `s3://${bucket}/models/${jobName}/`;
-
-    const { SageMakerClient, CreateTrainingJobCommand } = await import(
-      '@aws-sdk/client-sagemaker'
-    );
-
-    const sm = new SageMakerClient({ region });
-    const channelName = trainingBackend === 'xgboost_builtin' ? 'train' : 'training';
-
-    const hyperParameters: Record<string, string> = {};
-    if (trainingBackend === 'xgboost_builtin') {
-      hyperParameters.objective = process.env.XGBOOST_OBJECTIVE ?? 'reg:squarederror';
-      hyperParameters.eval_metric = process.env.XGBOOST_EVAL_METRIC ?? 'rmse';
-      hyperParameters.num_round = process.env.XGBOOST_NUM_ROUND ?? '220';
-      hyperParameters.max_depth = process.env.XGBOOST_MAX_DEPTH ?? '6';
-      hyperParameters.eta = process.env.XGBOOST_ETA ?? '0.1';
-      hyperParameters.subsample = process.env.XGBOOST_SUBSAMPLE ?? '0.85';
-      hyperParameters.colsample_bytree = process.env.XGBOOST_COLSAMPLE_BYTREE ?? '0.85';
-    } else {
-      hyperParameters.model_version_id = modelVersionId;
+    const examples = await buildRetrievalTrainingExamples(db);
+    if (examples.length === 0) {
+      throw new Error('No lambdarank training rows were exported from RetrievalAudit + Feedback');
     }
 
-    await sm.send(
-      new CreateTrainingJobCommand({
-        TrainingJobName: jobName,
-        AlgorithmSpecification: {
-          TrainingImage: trainingImage,
-          TrainingInputMode: 'File',
-        },
-        RoleArn: roleArn,
-        InputDataConfig: [
-          {
-            ChannelName: channelName,
-            DataSource: {
-              S3DataSource: {
-                S3DataType: 'S3Prefix',
-                S3Uri: exportResult.s3PrefixUri,
-                S3DataDistributionType: 'FullyReplicated',
-              },
-            },
-            ContentType: 'text/csv',
-          },
-        ],
-        OutputDataConfig: {
-          S3OutputPath: s3OutputPath,
-        },
-        ResourceConfig: {
-          InstanceType: 'ml.m5.large',
-          InstanceCount: 1,
-          VolumeSizeInGB: 10,
-        },
-        StoppingCondition: {
-          MaxRuntimeInSeconds: 3600,
-        },
-        HyperParameters: hyperParameters,
-        Tags: [
-          { Key: 'Project', Value: 'CropCopilot' },
-          { Key: 'ModelVersionId', Value: modelVersionId },
-          { Key: 'TrainingBackend', Value: trainingBackend },
-        ],
-      }),
-    );
+    const defaultArtifact = getDefaultModelArtifact('lambdarank', [...RETRIEVAL_FEATURE_NAMES]);
+    const artifact = trainLinearRankingModel({
+      modelType: 'lambdarank',
+      featureNames: [...RETRIEVAL_FEATURE_NAMES],
+      examples,
+      defaultWeights: defaultArtifact.featureWeights,
+    });
 
-    console.log(`[RetrainTrigger] SageMaker training job submitted: ${jobName}`);
+    const deployment = await deployInHouseModelArtifact(db, {
+      modelVersionId,
+      artifact,
+      bucket: process.env.S3_TRAINING_BUCKET ?? null,
+      region: process.env.AWS_REGION ?? 'us-west-2',
+    });
+
     await recordPipelineEvent(db, {
       pipeline: 'learning',
-      stage: 'retrain_submit',
+      stage: 'retrain_deploy',
       severity: 'info',
-      message: `Submitted lambdarank training job ${jobName}.`,
+      message: 'Deployed lambdarank artifact from in-house trainer.',
       metadata: {
         modelType: 'lambdarank',
-        jobName,
         modelVersionId,
         samples: newFeedbackCount,
-        trainingRows: exportResult.rowCount,
-        trainingBackend,
+        trainingRows: examples.length,
+        backend: artifact.backend,
+        ndcgAt3: artifact.metrics.ndcgAt3,
+        ndcgAt5: artifact.metrics.ndcgAt5,
+        pairwiseAccuracy: artifact.metrics.pairwiseAccuracy,
+        baselineNdcgAt3: artifact.metrics.baselineNdcgAt3,
+        baselineNdcgAt5: artifact.metrics.baselineNdcgAt5,
+        s3Uri: deployment.s3Uri,
       },
     });
-
-    await db.query(
-      `UPDATE "MLModelVersion" SET "s3Uri" = $1, "updatedAt" = NOW() WHERE id = $2`,
-      [`${s3OutputPath}output/model.tar.gz`, modelVersionId],
-    );
   } catch (error) {
-    const message = (error as Error).message;
-    console.error('[RetrainTrigger] Job submission failed:', message);
-    const isQuotaBlocked =
-      (error as { name?: string }).name === 'ResourceLimitExceeded' ||
-      /resource.?limit.?exceeded/i.test(message) ||
-      /training job usage/i.test(message);
-
-    if (isQuotaBlocked) {
-      await recordPipelineEvent(db, {
-        pipeline: 'learning',
-        stage: 'retrain_submit',
-        severity: 'warn',
-        message:
-          'Lambdarank retrain skipped because SageMaker training quota is unavailable in this account/region.',
-        metadata: {
-          modelType: 'lambdarank',
-          modelVersionId,
-          reason: message,
-        },
-      });
-      await db.query(
-        `UPDATE "MLModelVersion" SET status = 'retired', "updatedAt" = NOW() WHERE id = $1`,
-        [modelVersionId],
-      );
-      return;
-    }
-
+    await retireModelVersion(db, modelVersionId);
     await recordPipelineEvent(db, {
       pipeline: 'learning',
-      stage: 'retrain_submit',
+      stage: 'retrain_deploy',
       severity: 'error',
-      message: `Lambdarank retrain failed: ${message}`,
+      message: `Lambdarank retrain failed: ${(error as Error).message}`,
       metadata: {
         modelType: 'lambdarank',
         modelVersionId,
       },
     });
-    await db.query(
-      `UPDATE "MLModelVersion" SET status = 'retired', "updatedAt" = NOW() WHERE id = $1`,
-      [modelVersionId],
-    );
     throw error;
   }
 };

--- a/apps/api/src/pipeline/recommendation-pipeline.ts
+++ b/apps/api/src/pipeline/recommendation-pipeline.ts
@@ -3,12 +3,14 @@ import { Pool } from 'pg';
 import type { CreateInputCommand, RecommendationResult } from '@crop-copilot/contracts';
 import { resolvePoolSslConfig, sanitizeDatabaseUrlForPool } from '../lib/store';
 import { rankCandidates } from '../rag/hybrid-ranker';
-import { rerank } from '../ml/reranker';
+import { RETRIEVAL_FEATURE_NAMES, rerank } from '../ml/reranker';
 import { applyMMR } from '../rag/mmr';
 import { generateHypotheticalPassage } from '../rag/hyde';
 import { expandRetrievalQuery, type QueryExpansionResult } from '../rag/query-expansion';
 import type { RankedCandidate, RetrievedCandidate, SourceAuthorityType } from '../rag/types';
 import { CROPS } from '../ingestion/discovery-seeds';
+import { getLatestDeployedModelArtifact } from '../ml/model-registry';
+import type { InHouseLinearModelArtifact } from '../ml/in-house-models';
 
 export interface RecommendationPipelineInput {
   inputId: string;
@@ -105,6 +107,7 @@ export interface RecommendationPipelineDependencies {
     input: InputSnapshot,
     expansion: QueryExpansionResult
   ) => Promise<RetrievedCandidate[]>;
+  loadDeployedRerankerModel?: () => Promise<InHouseLinearModelArtifact | null>;
   generateModelOutput?: (
     params: ModelGenerationInput
   ) => Promise<ModelGenerationResult | null>;
@@ -175,6 +178,18 @@ function resolvePool(): Pool {
   return sharedPool;
 }
 
+async function loadDeployedRerankerModelFromRegistry(): Promise<InHouseLinearModelArtifact | null> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    return null;
+  }
+
+  return getLatestDeployedModelArtifact(resolvePool(), {
+    modelType: 'lambdarank',
+    featureNames: [...RETRIEVAL_FEATURE_NAMES],
+  });
+}
+
 export async function runRecommendationPipeline(
   input: RecommendationPipelineInput,
   dependencies: RecommendationPipelineDependencies = {}
@@ -184,6 +199,8 @@ export async function runRecommendationPipeline(
     dependencies.loadInputSnapshot ?? loadInputSnapshotFromDatabase;
   const retrieveCandidates =
     dependencies.retrieveCandidates ?? retrieveCandidatesFromKnowledgeBase;
+  const loadDeployedRerankerModel =
+    dependencies.loadDeployedRerankerModel ?? loadDeployedRerankerModelFromRegistry;
   const generateModelOutput =
     dependencies.generateModelOutput ?? generateModelOutputFromProviders;
   const usingDefaultModelGenerator = !dependencies.generateModelOutput;
@@ -223,11 +240,13 @@ export async function runRecommendationPipeline(
   // MMR: diversify top candidates so Claude gets varied evidence, not duplicates.
   const diversified = applyMMR(ranked, MAX_CONTEXT_CANDIDATES * 2, 0.65);
 
-  // Rerank with learned model when SageMaker endpoint is configured;
-  // falls back to MMR-diversified order on any failure.
+  const deployedRerankerModel = await loadDeployedRerankerModel();
+
+  // Re-score candidates with the latest deployed in-house ranking artifact.
   const reranked = await rerank(diversified, {
     crop: inputSnapshot.crop,
     queryTerms: queryExpansion.terms,
+    model: deployedRerankerModel,
   });
   const candidatePool = reranked ?? diversified;
   const filteredCandidates = filterCandidatesForDiagnosis(candidatePool, inputSnapshot);

--- a/apps/api/src/premium/enrichment-service.ts
+++ b/apps/api/src/premium/enrichment-service.ts
@@ -15,6 +15,8 @@ import {
   type ComplianceCheckResult,
   type PremiumInsightPayload,
 } from './types';
+import { getLatestDeployedModelArtifact } from '../ml/model-registry';
+import { PREMIUM_FEATURE_NAMES, buildPremiumQualityCheck } from '../ml/premium-quality';
 
 export async function runPremiumEnrichment(params: {
   pool: Pool;
@@ -131,6 +133,28 @@ export async function runPremiumEnrichment(params: {
       sources: sprayWindows.map((window) => window.source),
     },
   });
+
+  const provisionalChecks = [...compliance.checks, ...supplementalChecks];
+  const provisionalRiskReview = deriveRiskReviewDecision(provisionalChecks);
+
+  const premiumQualityModel = await getLatestDeployedModelArtifact(pool, {
+    modelType: 'premium_quality',
+    featureNames: [...PREMIUM_FEATURE_NAMES],
+  });
+  supplementalChecks.push(
+    buildPremiumQualityCheck({
+      artifact: premiumQualityModel,
+      payload: {
+        riskReview: provisionalRiskReview,
+        checks: provisionalChecks,
+        costAnalysis,
+        sprayWindows,
+        report: {
+          generatedAt: new Date().toISOString(),
+        },
+      },
+    })
+  );
 
   const checks = [...compliance.checks, ...supplementalChecks];
   const riskReview = deriveRiskReviewDecision(checks);

--- a/apps/api/src/scripts/release-readiness-audit.ts
+++ b/apps/api/src/scripts/release-readiness-audit.ts
@@ -173,7 +173,7 @@ async function fetchMetrics(db: Client): Promise<Record<string, unknown>> {
                 AND EXISTS (
                   SELECT 1
                   FROM jsonb_array_elements(COALESCE(rpi.checks, '[]'::jsonb)) c
-                  WHERE c->>'id' = 'diagnosis_quality'
+                  WHERE c->>'id' IN ('diagnosis_quality', 'premium_quality_confidence')
                 )
             )::text AS quality_check_present
           FROM "RecommendationPremiumInsight" rpi

--- a/apps/web/app/(app)/admin/discovery/page.tsx
+++ b/apps/web/app/(app)/admin/discovery/page.tsx
@@ -33,6 +33,7 @@ interface LatestModel {
   feedbackCount: number;
   ndcgScore: number | null;
   s3Uri: string | null;
+  backend?: string | null;
 }
 
 interface ObservabilityEvent {
@@ -526,6 +527,12 @@ export default async function DiscoveryStatusPage() {
                     <p className="text-xs text-muted-foreground mb-1">Model type</p>
                     <p className="font-medium">{latestModel.modelType}</p>
                   </div>
+                  {latestModel.backend && (
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-1">Backend</p>
+                      <p className="font-medium">{latestModel.backend}</p>
+                    </div>
+                  )}
                   <div>
                     <p className="text-xs text-muted-foreground mb-1">Trained at</p>
                     <p className="font-medium">{formatDate(latestModel.trainedAt)}</p>
@@ -580,6 +587,12 @@ export default async function DiscoveryStatusPage() {
                         <p className="text-xs text-muted-foreground mb-1">Model type</p>
                         <p className="font-medium">{latestPremiumModel.modelType}</p>
                       </div>
+                      {latestPremiumModel.backend && (
+                        <div>
+                          <p className="text-xs text-muted-foreground mb-1">Backend</p>
+                          <p className="font-medium">{latestPremiumModel.backend}</p>
+                        </div>
+                      )}
                       <div>
                         <p className="text-xs text-muted-foreground mb-1">Trained at</p>
                         <p className="font-medium">{formatDate(latestPremiumModel.trainedAt)}</p>

--- a/apps/web/app/(app)/admin/page.tsx
+++ b/apps/web/app/(app)/admin/page.tsx
@@ -35,6 +35,7 @@ interface ModelStatus {
   ndcgScore: number | null;
   feedbackCount: number;
   s3Uri: string | null;
+  backend?: string | null;
 }
 
 interface AdminStatusResponse {
@@ -502,6 +503,11 @@ export default async function AdminPage() {
                       <p>
                         Model: <span className="font-medium text-foreground">{model.modelType}</span>
                       </p>
+                      {model.backend && (
+                        <p>
+                          Backend: <span className="font-medium text-foreground">{model.backend}</span>
+                        </p>
+                      )}
                       <p>
                         Trained: <span className="font-medium text-foreground">{timeAgo(model.trainedAt)}</span>
                       </p>

--- a/apps/web/app/(auth)/callback/route.ts
+++ b/apps/web/app/(auth)/callback/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const next = searchParams.get('next') ?? '/dashboard'
 
-  if (getAuthProvider() === 'cognito') {
+  if (getAuthProvider() !== 'supabase') {
     return NextResponse.redirect(`${origin}${next}`)
   }
 

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,11 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildLocalSession, isLocalAuthRequest } from '@/lib/auth/local-auth';
 import { getAuthProvider } from '@/lib/auth/provider';
 import { signInWithPassword } from '@/lib/auth/cognito-public';
 import { buildSessionFromTokens } from '@/lib/auth/cognito-jwt';
 import { writeCognitoCookies } from '@/lib/auth/cognito-cookies';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (getAuthProvider() !== 'cognito') {
+  const provider = getAuthProvider();
+
+  if (provider === 'local') {
+    if (!isLocalAuthRequest(request)) {
+      return NextResponse.json(
+        { error: { message: 'Local auth is restricted to localhost development.' } },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({ session: buildLocalSession() });
+  }
+
+  if (provider !== 'cognito') {
     return NextResponse.json(
       { error: { message: 'Cognito auth is not enabled.' } },
       { status: 404 }

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,10 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { clearCognitoCookies, readCognitoCookiesFromRequest } from '@/lib/auth/cognito-cookies';
+import { isLocalAuthRequest } from '@/lib/auth/local-auth';
 import { globalSignOut } from '@/lib/auth/cognito-public';
 import { getAuthProvider } from '@/lib/auth/provider';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (getAuthProvider() !== 'cognito') {
+  const provider = getAuthProvider();
+
+  if (provider === 'local') {
+    if (!isLocalAuthRequest(request)) {
+      return NextResponse.json(
+        { error: { message: 'Local auth is restricted to localhost development.' } },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  }
+
+  if (provider !== 'cognito') {
     return NextResponse.json({ ok: true });
   }
 

--- a/apps/web/app/api/auth/session/route.ts
+++ b/apps/web/app/api/auth/session/route.ts
@@ -5,6 +5,7 @@ import {
   readCognitoCookiesFromRequest,
   writeCognitoCookies,
 } from '@/lib/auth/cognito-cookies';
+import { buildLocalSession, isLocalAuthRequest } from '@/lib/auth/local-auth';
 import { refreshSession } from '@/lib/auth/cognito-public';
 import { getAuthProvider } from '@/lib/auth/provider';
 
@@ -12,7 +13,20 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  if (getAuthProvider() !== 'cognito') {
+  const provider = getAuthProvider();
+
+  if (provider === 'local') {
+    if (!isLocalAuthRequest(request)) {
+      return NextResponse.json(
+        { error: { message: 'Local auth is restricted to localhost development.' } },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({ session: buildLocalSession() });
+  }
+
+  if (provider !== 'cognito') {
     return NextResponse.json({ session: null });
   }
 

--- a/apps/web/app/api/auth/signup/route.ts
+++ b/apps/web/app/api/auth/signup/route.ts
@@ -1,11 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildLocalSession, isLocalAuthRequest } from '@/lib/auth/local-auth';
 import { getAuthProvider } from '@/lib/auth/provider';
 import { signUpWithPassword } from '@/lib/auth/cognito-public';
 import { buildSessionFromTokens } from '@/lib/auth/cognito-jwt';
 import { writeCognitoCookies } from '@/lib/auth/cognito-cookies';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (getAuthProvider() !== 'cognito') {
+  const provider = getAuthProvider();
+
+  if (provider === 'local') {
+    if (!isLocalAuthRequest(request)) {
+      return NextResponse.json(
+        { error: { message: 'Local auth is restricted to localhost development.' } },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({ session: buildLocalSession() }, { status: 201 });
+  }
+
+  if (provider !== 'cognito') {
     return NextResponse.json(
       { error: { message: 'Cognito auth is not enabled.' } },
       { status: 404 }

--- a/apps/web/lib/auth/local-auth.ts
+++ b/apps/web/lib/auth/local-auth.ts
@@ -1,0 +1,118 @@
+import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
+import type { NextRequest } from 'next/server';
+import type { AppAuthClient, AppAuthError, AppAuthSession, AppAuthUser } from './types';
+
+const DEFAULT_LOCAL_USER_ID = '80d8a54f-5c9b-4094-905a-862baadfdb3c';
+const DEFAULT_LOCAL_EMAIL = 'avirajdhooria2001@gmail.com';
+const DEFAULT_LOCAL_TOKEN = 'crop-copilot-local-dev-token';
+
+function toError(message: string): AppAuthError {
+  return { message };
+}
+
+function isAllowedLocalHost(hostname: string | null | undefined): boolean {
+  const normalized = (hostname ?? '').trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '0.0.0.0' ||
+    normalized === '::1' ||
+    normalized.endsWith('.localhost')
+  );
+}
+
+export function isLocalAuthRequestHost(hostname: string | null | undefined): boolean {
+  return isAllowedLocalHost(hostname);
+}
+
+export function isLocalAuthRuntimeAllowed(): boolean {
+  return process.env.NODE_ENV !== 'production';
+}
+
+export function getLocalAuthUser(): AppAuthUser {
+  return {
+    id: process.env.LOCAL_AUTH_USER_ID?.trim() || DEFAULT_LOCAL_USER_ID,
+    email: process.env.LOCAL_AUTH_EMAIL?.trim() || DEFAULT_LOCAL_EMAIL,
+  };
+}
+
+export function getLocalAuthToken(): string {
+  return process.env.LOCAL_AUTH_BEARER_TOKEN?.trim() || DEFAULT_LOCAL_TOKEN;
+}
+
+export function buildLocalSession(): AppAuthSession {
+  return {
+    access_token: getLocalAuthToken(),
+    token_type: 'Bearer',
+    user: getLocalAuthUser(),
+    provider: 'local',
+  };
+}
+
+function validateLocalCredentials(email: string): AppAuthError | null {
+  if (!isLocalAuthRuntimeAllowed()) {
+    return toError('Local auth is disabled outside local development.');
+  }
+
+  const expected = (getLocalAuthUser().email ?? '').toLowerCase();
+  if (email.trim().toLowerCase() !== expected) {
+    return toError(`Local auth only allows ${expected}.`);
+  }
+
+  return null;
+}
+
+function buildLocalClient(): AppAuthClient {
+  return {
+    auth: {
+      async getSession() {
+        return { data: { session: buildLocalSession() }, error: null };
+      },
+      async getUser() {
+        return { data: { user: getLocalAuthUser() }, error: null };
+      },
+      async signInWithPassword(input) {
+        const error = validateLocalCredentials(input.email);
+        return {
+          data: {
+            session: error ? null : buildLocalSession(),
+            user: error ? null : getLocalAuthUser(),
+          },
+          error,
+        };
+      },
+      async signUp(input) {
+        const error = validateLocalCredentials(input.email);
+        return {
+          data: {
+            session: error ? null : buildLocalSession(),
+            user: error ? null : getLocalAuthUser(),
+          },
+          error,
+        };
+      },
+      async signOut() {
+        return { error: null };
+      },
+      async exchangeCodeForSession() {
+        return { error: null };
+      },
+    },
+  };
+}
+
+export function createLocalBrowserAuthClient(): AppAuthClient {
+  return buildLocalClient();
+}
+
+export function createLocalServerAuthClient(_cookieStore: ReadonlyRequestCookies): AppAuthClient {
+  return buildLocalClient();
+}
+
+export function isLocalAuthRequest(request: NextRequest): boolean {
+  return isLocalAuthRuntimeAllowed() && isLocalAuthRequestHost(request.nextUrl.hostname);
+}

--- a/apps/web/lib/auth/provider.ts
+++ b/apps/web/lib/auth/provider.ts
@@ -1,4 +1,4 @@
-export type AuthProvider = 'supabase' | 'cognito';
+export type AuthProvider = 'supabase' | 'cognito' | 'local';
 
 function isTruthy(value: string | undefined): boolean {
   return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase());
@@ -6,7 +6,7 @@ function isTruthy(value: string | undefined): boolean {
 
 export function getAuthProvider(): AuthProvider {
   const explicit = process.env.NEXT_PUBLIC_AUTH_PROVIDER?.trim().toLowerCase();
-  if (explicit === 'cognito' || explicit === 'supabase') {
+  if (explicit === 'local' || explicit === 'cognito' || explicit === 'supabase') {
     return explicit;
   }
 

--- a/apps/web/lib/auth/types.ts
+++ b/apps/web/lib/auth/types.ts
@@ -10,7 +10,7 @@ export interface AppAuthSession {
   token_type?: string;
   expires_at?: number;
   user: AppAuthUser;
-  provider: 'supabase' | 'cognito';
+  provider: 'supabase' | 'cognito' | 'local';
 }
 
 export interface AppAuthError {

--- a/apps/web/lib/supabase/client.ts
+++ b/apps/web/lib/supabase/client.ts
@@ -1,10 +1,17 @@
 import { createCognitoBrowserAuthClient } from '@/lib/auth/cognito-browser-client';
+import { createLocalBrowserAuthClient } from '@/lib/auth/local-auth';
 import { getAuthProvider } from '@/lib/auth/provider';
 import { createSupabaseBrowserAuthClient } from '@/lib/auth/supabase-adapter';
 import type { AppAuthClient } from '@/lib/auth/types';
 
 export function createClient(): AppAuthClient {
-  if (getAuthProvider() === 'cognito') {
+  const provider = getAuthProvider();
+
+  if (provider === 'local') {
+    return createLocalBrowserAuthClient();
+  }
+
+  if (provider === 'cognito') {
     return createCognitoBrowserAuthClient();
   }
 

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -1,13 +1,19 @@
 import { cookies } from 'next/headers';
 import { createCognitoServerAuthClient } from '@/lib/auth/cognito-server-client';
+import { createLocalServerAuthClient } from '@/lib/auth/local-auth';
 import { getAuthProvider } from '@/lib/auth/provider';
 import { createSupabaseServerAuthClient } from '@/lib/auth/supabase-adapter';
 import type { AppAuthClient } from '@/lib/auth/types';
 
 export async function createClient(): Promise<AppAuthClient> {
   const cookieStore = await cookies();
+  const provider = getAuthProvider();
 
-  if (getAuthProvider() === 'cognito') {
+  if (provider === 'local') {
+    return createLocalServerAuthClient(cookieStore as any);
+  }
+
+  if (provider === 'cognito') {
     return createCognitoServerAuthClient(cookieStore as any);
   }
 

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -5,6 +5,7 @@ import {
   COGNITO_ID_TOKEN_COOKIE,
   COGNITO_REFRESH_TOKEN_COOKIE,
 } from '@/lib/auth/cognito-cookies';
+import { isLocalAuthRequest } from '@/lib/auth/local-auth';
 import { getAuthProvider } from '@/lib/auth/provider';
 
 const protectedPaths = ['/dashboard', '/diagnose', '/recommendations', '/products', '/history', '/settings', '/admin'];
@@ -88,8 +89,28 @@ function handleCognitoMiddleware(request: NextRequest): NextResponse {
   return NextResponse.next({ request: { headers: request.headers } });
 }
 
+function handleLocalMiddleware(request: NextRequest): NextResponse {
+  if (!isLocalAuthRequest(request)) {
+    return new NextResponse('Local auth is restricted to localhost development.', { status: 403 });
+  }
+
+  if (isAuthPath(request.nextUrl.pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/dashboard';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next({ request: { headers: request.headers } });
+}
+
 export async function middleware(request: NextRequest) {
-  if (getAuthProvider() === 'cognito') {
+  const provider = getAuthProvider();
+
+  if (provider === 'local') {
+    return handleLocalMiddleware(request);
+  }
+
+  if (provider === 'cognito') {
     return handleCognitoMiddleware(request);
   }
 

--- a/docs/plans/stripe-setup-grower-plans.md
+++ b/docs/plans/stripe-setup-grower-plans.md
@@ -66,9 +66,9 @@ Important:
 ## 4. Environment Variables
 Set these in runtime:
 - `ALLOW_BILLING_SIMULATION=false`
-- `STRIPE_SECRET_KEY=<sk_test_... or sk_live_...>` (needed for direct Stripe API session creation)
-- `STRIPE_PUBLISHABLE_KEY=<pk_test_... or pk_live_...>`
-- `STRIPE_WEBHOOK_SECRET=<whsec_...>`
+- `STRIPE_SECRET_KEY=<Stripe secret key>` (needed for direct Stripe API session creation)
+- `STRIPE_PUBLISHABLE_KEY=<Stripe publishable key>`
+- `STRIPE_WEBHOOK_SECRET=<Stripe webhook signing secret>`
 - `BILLING_PORTAL_RETURN_URL=https://<your-domain>/settings/billing`
 - `STRIPE_PRICE_GROWER_FREE=<price_...>`
 - `STRIPE_PRICE_GROWER=<price_...>`

--- a/infra/lib/stacks/api-runtime-stack.ts
+++ b/infra/lib/stacks/api-runtime-stack.ts
@@ -433,9 +433,6 @@ export class ApiRuntimeStack extends Stack {
       XGBOOST_ETA: process.env.XGBOOST_ETA ?? '0.1',
       XGBOOST_SUBSAMPLE: process.env.XGBOOST_SUBSAMPLE ?? '0.85',
       XGBOOST_COLSAMPLE_BYTREE: process.env.XGBOOST_COLSAMPLE_BYTREE ?? '0.85',
-      SAGEMAKER_INFERENCE_IMAGE: process.env.SAGEMAKER_INFERENCE_IMAGE ?? '',
-      SAGEMAKER_ENDPOINT_CONTAINER_MODE: process.env.SAGEMAKER_ENDPOINT_CONTAINER_MODE ?? 'native',
-      SAGEMAKER_INFERENCE_PROGRAM: process.env.SAGEMAKER_INFERENCE_PROGRAM ?? 'inference.py',
     };
 
     const mlRuntimeEnvironment: Record<string, string> = {
@@ -446,10 +443,10 @@ export class ApiRuntimeStack extends Stack {
       METRICS_NAMESPACE: environment.METRICS_NAMESPACE ?? 'CropCopilot/Pipeline',
       RETRAINING_MIN_FEEDBACK: environment.RETRAINING_MIN_FEEDBACK ?? '50',
       PREMIUM_RETRAINING_MIN_FEEDBACK: environment.PREMIUM_RETRAINING_MIN_FEEDBACK ?? '30',
-      SAGEMAKER_ENDPOINT_NAME: environment.SAGEMAKER_ENDPOINT_NAME ?? '',
     };
 
-    // Nightly ML model retraining: exports training data to S3, submits SageMaker job
+    // Nightly ML model retraining: exports examples, trains in-house artifacts,
+    // and promotes them by updating MLModelVersion.
     const retrainTriggerWorker = mlAutomationEnabled
       ? createApiFunction(this, {
           id: 'RetrainTriggerWorker',
@@ -469,18 +466,6 @@ export class ApiRuntimeStack extends Stack {
           extraEnvironment: mlTrainingEnvironment,
           memorySize: 512,
           timeout: Duration.minutes(10),
-        })
-      : null;
-
-    // Triggered by SageMaker training completion event — promotes new model to endpoint
-    const endpointUpdaterWorker = mlAutomationEnabled
-      ? createApiFunction(this, {
-          id: 'EndpointUpdaterWorker',
-          entry: 'ml/training/endpoint-updater.ts',
-          environment: mlRuntimeEnvironment,
-          extraEnvironment: mlTrainingEnvironment,
-          memorySize: 256,
-          timeout: Duration.seconds(60),
         })
       : null;
 
@@ -557,47 +542,11 @@ export class ApiRuntimeStack extends Stack {
     foundation.ingestionQueue.grantSendMessages(runIngestionBatchWorker);
     foundation.ingestionQueue.grantSendMessages(registerSourceHandler);
 
-    // RetrainTriggerWorker reads/writes training data and model artifacts
+    // ML training workers read/write model artifacts and observability data.
     if (retrainTriggerWorker && retrainPremiumTriggerWorker && processModelTrainingTriggerWorker) {
       foundation.artifactsBucket.grantReadWrite(retrainTriggerWorker);
       foundation.artifactsBucket.grantReadWrite(retrainPremiumTriggerWorker);
       foundation.artifactsBucket.grantReadWrite(processModelTrainingTriggerWorker);
-      retrainTriggerWorker.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: ['sagemaker:CreateTrainingJob', 'sagemaker:AddTags', 'iam:PassRole'],
-          resources: ['*'],
-        }),
-      );
-      retrainPremiumTriggerWorker.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: ['sagemaker:CreateTrainingJob', 'sagemaker:AddTags', 'iam:PassRole'],
-          resources: ['*'],
-        }),
-      );
-      processModelTrainingTriggerWorker.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: ['sagemaker:CreateTrainingJob', 'sagemaker:AddTags', 'iam:PassRole'],
-          resources: ['*'],
-        }),
-      );
-    }
-
-    if (endpointUpdaterWorker) {
-      endpointUpdaterWorker.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: [
-            'sagemaker:DescribeTrainingJob',
-            'sagemaker:CreateModel',
-            'sagemaker:CreateEndpointConfig',
-            'sagemaker:CreateEndpoint',
-            'sagemaker:UpdateEndpoint',
-            'sagemaker:DescribeEndpoint',
-            'sagemaker:AddTags',
-            'iam:PassRole',
-          ],
-          resources: ['*'],
-        }),
-      );
     }
 
     // DiscoverSourcesWorker enqueues newly found sources for ingestion
@@ -615,13 +564,8 @@ export class ApiRuntimeStack extends Stack {
     });
     runIngestionScheduleRule.addTarget(new eventsTargets.LambdaFunction(runIngestionBatchWorker));
 
-    // ML retraining: fires nightly at 02:00 UTC, exports CSV + submits SageMaker job
-    if (
-      mlAutomationEnabled &&
-      retrainTriggerWorker &&
-      retrainPremiumTriggerWorker &&
-      endpointUpdaterWorker
-    ) {
+    // ML retraining: fires nightly and produces in-house model artifacts.
+    if (mlAutomationEnabled && retrainTriggerWorker && retrainPremiumTriggerWorker) {
       const retrainScheduleRule = new events.Rule(this, 'RetrainTriggerScheduleRule', {
         ruleName: `${config.projectSlug}-${config.envName}-ml-retrain-schedule`,
         schedule: events.Schedule.cron({ minute: '0', hour: '2' }),
@@ -642,18 +586,6 @@ export class ApiRuntimeStack extends Stack {
       retrainPremiumScheduleRule.addTarget(
         new eventsTargets.LambdaFunction(retrainPremiumTriggerWorker)
       );
-
-      const sageMakerCompleteRule = new events.Rule(this, 'SageMakerTrainingCompleteRule', {
-        ruleName: `${config.projectSlug}-${config.envName}-sagemaker-training-complete`,
-        description:
-          'Triggers endpoint update when a CropCopilot SageMaker training job completes.',
-        eventPattern: {
-          source: ['aws.sagemaker'],
-          detailType: ['SageMaker Training Job State Change'],
-          detail: { TrainingJobStatus: ['Completed', 'Failed', 'Stopped'] },
-        },
-      });
-      sageMakerCompleteRule.addTarget(new eventsTargets.LambdaFunction(endpointUpdaterWorker));
     }
 
     // Crop × region discovery: monthly on the 1st at 06:00 UTC.
@@ -1153,10 +1085,6 @@ function buildApiEnvironment(
   const supabaseAnonKey =
     process.env.SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const mlAutomationEnabled = parseBooleanEnv(process.env.ENABLE_ML_AUTOMATION, false);
-  const sagemakerEndpointEnabled = parseBooleanEnv(
-    process.env.ENABLE_SAGEMAKER_REALTIME_ENDPOINT,
-    false
-  );
 
   const cognitoRegion = process.env.COGNITO_REGION ?? Stack.of(foundation).region;
   const cognitoUserPoolId =
@@ -1197,14 +1125,11 @@ function buildApiEnvironment(
     OPENAI_EMBEDDING_MODEL: process.env.OPENAI_EMBEDDING_MODEL ?? '',
     RAG_RETRIEVAL_LIMIT: process.env.RAG_RETRIEVAL_LIMIT ?? '18',
     PG_POOL_MAX: process.env.PG_POOL_MAX ?? '6',
-    // SageMaker reranker (leave empty to disable; reranker falls back to hybrid ranking)
+    // In-house reranker: disable only for incident response or debugging.
     ENABLE_ML_AUTOMATION: mlAutomationEnabled ? 'true' : 'false',
-    ENABLE_SAGEMAKER_REALTIME_ENDPOINT: sagemakerEndpointEnabled ? 'true' : 'false',
-    DISABLE_RERANKER:
-      process.env.DISABLE_RERANKER ?? (sagemakerEndpointEnabled ? '0' : '1'),
-    SAGEMAKER_ENDPOINT_NAME: sagemakerEndpointEnabled
-      ? process.env.SAGEMAKER_ENDPOINT_NAME ?? ''
-      : '',
+    ENABLE_SAGEMAKER_REALTIME_ENDPOINT: 'false',
+    DISABLE_RERANKER: process.env.DISABLE_RERANKER ?? '0',
+    SAGEMAKER_ENDPOINT_NAME: '',
     RETRAINING_MIN_FEEDBACK: process.env.RETRAINING_MIN_FEEDBACK ?? '50',
     PREMIUM_RETRAINING_MIN_FEEDBACK: process.env.PREMIUM_RETRAINING_MIN_FEEDBACK ?? '30',
     // PDF parsing via LlamaParse (1000 free pages/day; leave empty to skip PDFs)

--- a/tools/aws/ops-audit.mjs
+++ b/tools/aws/ops-audit.mjs
@@ -203,6 +203,21 @@ function buildFindings({ inventory, serviceCosts, rdsUsageCosts }) {
     });
   }
 
+  const attachedElasticIps = Object.entries(inventory).flatMap(([region, data]) =>
+    (data.elasticIps ?? [])
+      .filter((address) => address.networkInterfaceId || address.associationId)
+      .map((address) => ({ region, address }))
+  );
+  if (attachedElasticIps.length > 0) {
+    findings.push({
+      severity: 'low',
+      code: 'attached_elastic_ips',
+      message: `Elastic IPs still attached in the runtime footprint: ${attachedElasticIps
+        .map((item) => `${item.address.publicIp}@${item.region}`)
+        .join(', ')}.`,
+    });
+  }
+
   const auditErrors = Object.entries(inventory).flatMap(([region, data]) =>
     (data.auditErrors ?? []).map((error) => ({ region, error }))
   );
@@ -217,6 +232,79 @@ function buildFindings({ inventory, serviceCosts, rdsUsageCosts }) {
   }
 
   return findings;
+}
+
+function daysElapsedInMonthUtc() {
+  return Math.max(1, new Date().getUTCDate());
+}
+
+function daysInCurrentMonthUtc() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0)).getUTCDate();
+}
+
+function projectForwardRunRate({ inventory, serviceCosts, rdsUsageCosts }) {
+  const serviceCostMap = new Map(serviceCosts.map((item) => [item.key, item.amountUsd]));
+  const daysElapsed = daysElapsedInMonthUtc();
+  const daysInMonth = daysInCurrentMonthUtc();
+
+  const publicDbCount = Object.values(inventory).reduce(
+    (sum, data) => sum + (data.dbInstances ?? []).filter((db) => db.public).length,
+    0
+  );
+  const elasticIpCount = Object.values(inventory).reduce(
+    (sum, data) => sum + (data.elasticIps ?? []).length,
+    0
+  );
+  const natGatewayCount = Object.values(inventory).reduce(
+    (sum, data) => sum + (data.natGateways ?? []).length,
+    0
+  );
+  const activeSagemakerEndpointCount = Object.values(inventory).reduce(
+    (sum, data) => sum + (data.sagemakerEndpoints ?? []).length,
+    0
+  );
+
+  const rdsProjected =
+    rdsUsageCosts.reduce((sum, item) => sum + item.amountUsd, 0) * (daysInMonth / daysElapsed);
+
+  const publicIpv4Projected =
+    natGatewayCount > 0
+      ? serviceCostMap.get('Amazon Virtual Private Cloud') ?? 0
+      : (publicDbCount + elasticIpCount) * 3.6;
+
+  const components = [
+    { key: 'RDS', amountUsd: rdsProjected },
+    { key: 'VPC', amountUsd: publicIpv4Projected },
+    { key: 'CloudWatch', amountUsd: serviceCostMap.get('AmazonCloudWatch') ?? 0 },
+    { key: 'SQS', amountUsd: serviceCostMap.get('Amazon Simple Queue Service') ?? 0 },
+    { key: 'SecretsManager', amountUsd: serviceCostMap.get('AWS Secrets Manager') ?? 0 },
+    { key: 'CostExplorer', amountUsd: serviceCostMap.get('AWS Cost Explorer') ?? 0 },
+    { key: 'ApiGateway', amountUsd: serviceCostMap.get('Amazon API Gateway') ?? 0 },
+    { key: 'S3', amountUsd: serviceCostMap.get('Amazon Simple Storage Service') ?? 0 },
+    { key: 'Lambda', amountUsd: serviceCostMap.get('AWS Lambda') ?? 0 },
+    {
+      key: 'SageMaker',
+      amountUsd:
+        activeSagemakerEndpointCount > 0
+          ? serviceCostMap.get('Amazon SageMaker') ?? 0
+          : 0,
+    },
+  ].filter((item) => item.amountUsd > 0);
+
+  return {
+    monthDays: daysInMonth,
+    elapsedDays: daysElapsed,
+    assumptions: {
+      publicDbCount,
+      elasticIpCount,
+      natGatewayCount,
+      activeSagemakerEndpointCount,
+      monthlyPublicIpv4UnitUsd: 3.6,
+    },
+    components,
+    totalAmountUsd: components.reduce((sum, item) => sum + item.amountUsd, 0),
+  };
 }
 
 function main() {
@@ -336,6 +424,7 @@ function main() {
   const serviceCosts = summarizeAcrossTime(costByService?.ResultsByTime);
   const rdsUsageCosts = summarizeAcrossTime(rdsUsage?.ResultsByTime);
   const findings = buildFindings({ inventory, serviceCosts, rdsUsageCosts });
+  const forwardRunRate = projectForwardRunRate({ inventory, serviceCosts, rdsUsageCosts });
 
   const report = {
     generatedAt: new Date().toISOString(),
@@ -343,6 +432,7 @@ function main() {
     regions: REGIONS,
     costLast30DaysByService: serviceCosts,
     monthToDateRdsUsage: rdsUsageCosts,
+    estimatedForwardMonthlyRunRate: forwardRunRate,
     inventory,
     findings,
   };
@@ -359,6 +449,7 @@ function main() {
     account: identity?.Account ?? null,
     reportFile: filename,
     topServices: serviceCosts.slice(0, 8),
+    estimatedForwardMonthlyRunRate: forwardRunRate,
     findings,
   };
   console.log(JSON.stringify(summary, null, 2));

--- a/tools/ops/generate-daily-digest.mjs
+++ b/tools/ops/generate-daily-digest.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+
+function latestMatchingFile(dir, prefix) {
+  const entries = readdirSync(dir)
+    .filter((name) => name.startsWith(prefix) && name.endsWith('.json'))
+    .sort((left, right) => right.localeCompare(left));
+  if (entries.length === 0) {
+    return null;
+  }
+  return resolve(dir, entries[0]);
+}
+
+function currency(value) {
+  return `$${Number(value ?? 0).toFixed(2)}`;
+}
+
+function pct(value) {
+  return `${Math.round(Number(value ?? 0) * 100)}%`;
+}
+
+function main() {
+  const reportsDir = resolve(process.cwd(), 'reports');
+  const awsPath = latestMatchingFile(reportsDir, 'aws-ops-audit-');
+  const readinessPath = latestMatchingFile(reportsDir, 'release-readiness-');
+
+  if (!awsPath && !readinessPath) {
+    throw new Error(`No audit inputs found in ${reportsDir}`);
+  }
+
+  const aws = awsPath ? JSON.parse(readFileSync(awsPath, 'utf8')) : {};
+  const readiness = readinessPath ? JSON.parse(readFileSync(readinessPath, 'utf8')) : {};
+
+  const topCosts = (aws.costLast30DaysByService ?? []).slice(0, 6);
+  const findings = aws.findings ?? [];
+  const blockers = (readiness.gaps ?? []).filter((gap) => gap.severity === 'blocker');
+  const warnings = (readiness.gaps ?? []).filter((gap) => gap.severity === 'warning');
+  const inventory = aws.inventory?.['us-west-2'] ?? {};
+  const dbInstances = inventory.dbInstances ?? [];
+  const elasticIps = inventory.elasticIps ?? [];
+
+  const md = `# Ops Daily Digest
+
+- Generated: ${new Date().toISOString()}
+- AWS audit source: ${awsPath ? basename(awsPath) : 'missing'}
+- Release audit source: ${readinessPath ? basename(readinessPath) : 'missing'}
+
+## Cost Snapshot
+
+${topCosts.length > 0 ? topCosts.map((entry) => `- ${entry.key}: ${currency(entry.amountUsd)}`).join('\n') : '- No AWS cost data'}
+
+## Forward Run Rate
+
+- Estimated AWS monthly floor: ${currency(aws.estimatedForwardMonthlyRunRate?.totalAmountUsd ?? 0)}
+${(aws.estimatedForwardMonthlyRunRate?.components ?? [])
+  .map((entry) => `- ${entry.key}: ${currency(entry.amountUsd)}`)
+  .join('\n') || '- No forward estimate'}
+
+## Live Inventory
+
+- us-west-2 stacks: ${inventory.stacks?.length ?? 0}
+- prod DB instances: ${dbInstances.length}
+- active SageMaker endpoints: ${(inventory.sagemakerEndpoints ?? []).length}
+- elastic IPs: ${elasticIps.length}
+
+${dbInstances
+  .map(
+    (db) =>
+      `- DB ${db.id}: ${db.class}, public=${db.public}, backupRetention=${db.backupRetention}d, storage=${db.allocated}GB`
+  )
+  .join('\n')}
+
+## Audit Findings
+
+${findings.length > 0 ? findings.map((finding) => `- [${finding.severity}] ${finding.message}`).join('\n') : '- None'}
+
+## Release Readiness
+
+- Blockers: ${blockers.length}
+- Warnings: ${warnings.length}
+
+${blockers.map((gap) => `- [blocker] ${gap.area}: ${gap.message}`).join('\n') || '- No blockers'}
+
+${warnings.map((gap) => `- [warning] ${gap.area}: ${gap.message}`).join('\n') || '- No warnings'}
+
+## Model Usage
+
+${(readiness.metrics?.recommendationModelUsage30d ?? [])
+  .map((entry) => `- ${entry.modelUsed}: ${entry.count}`)
+  .join('\n') || '- No model usage data'}
+
+## Premium Coverage
+
+- Ready insights: ${readiness.metrics?.premiumSummary?.ready_count ?? 0}
+- Live weather coverage: ${pct(
+    Number(readiness.metrics?.premiumSummary?.weather_live ?? 0) /
+      Math.max(1, Number(readiness.metrics?.premiumSummary?.weather_eligible ?? 0))
+  )}
+- Cost totals coverage: ${pct(
+    Number(readiness.metrics?.premiumSummary?.cost_totals ?? 0) /
+      Math.max(1, Number(readiness.metrics?.premiumSummary?.cost_eligible ?? 0))
+  )}
+- Learned premium quality check coverage: ${pct(
+    Number(readiness.metrics?.premiumSummary?.quality_check_present ?? 0) /
+      Math.max(1, Number(readiness.metrics?.premiumSummary?.ready_count ?? 0))
+  )}
+`;
+
+  const outputPath = resolve(
+    reportsDir,
+    `ops-daily-digest-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}.md`
+  );
+  writeFileSync(outputPath, md, 'utf8');
+  console.log(outputPath);
+}
+
+main();


### PR DESCRIPTION
Summary:\n- replace SageMaker retrieval reranking with in-house artifact scoring\n- replace managed retrain workers with local pairwise training artifacts\n- connect premium_quality training to runtime premium checks\n- add daily ops digest workflow and forward AWS run-rate estimate\n- harden prod DB ops resolution fallback\n\nValidation:\n- pnpm --filter @crop-copilot/api test\n- pnpm --filter @crop-copilot/api build\n- pnpm --filter web build\n- pnpm --filter infra build\n\nOperational notes:\n- fresh AWS audit confirms only one prod environment remains and no SageMaker endpoints are active\n- prod DB ops workflow fix still needs this PR merged before the no-op snapshot-first exercise can be rerun\n